### PR TITLE
Afmetingen 19x6 controleren

### DIFF
--- a/app/gardens/[id]/page.tsx
+++ b/app/gardens/[id]/page.tsx
@@ -36,7 +36,7 @@ const CANVAS_HEIGHT = 600
 const GRID_SIZE = 20
 const PLANTVAK_MIN_WIDTH = 100
 const PLANTVAK_MIN_HEIGHT = 80
-const METERS_TO_PIXELS = 50 // 1 meter = 50 pixels
+const METERS_TO_PIXELS = 42 // 1 meter = 42 pixels (optimized for 19m x 6m garden)
 
 interface PlantBedPosition {
   id: string


### PR DESCRIPTION
Adjust `METERS_TO_PIXELS` constant to correctly scale the garden view for a 19x6 meter garden plot.

---

**Open Background Agent:** 

[Web](https://www.cursor.com/agents?id=bc-8261e15a-d91c-475b-b93d-98dd5e7893a6) · [Cursor](https://cursor.com/background-agent?bcId=bc-8261e15a-d91c-475b-b93d-98dd5e7893a6)

Refer to [Background Agent docs](https://docs.cursor.com/background-agents)