### PR TITLE
Verwijder dubbele navigatie en verbeter taakdetails

### DIFF
--- a/app/gardens/[id]/plant-beds/[bedId]/plants/[plantId]/edit/page.tsx
+++ b/app/gardens/[id]/plant-beds/[bedId]/plants/[plantId]/edit/page.tsx
@@ -5,39 +5,14 @@ import { useRouter, useParams } from "next/navigation"
 import Link from "next/link"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
-import { Input } from "@/components/ui/input"
-import { Label } from "@/components/ui/label"
-import { Textarea } from "@/components/ui/textarea"
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
-import { FlowerSelector } from "@/components/ui/flower-selector"
+import { PlantForm, PlantFormData, PlantFormErrors, createInitialPlantFormData } from "@/components/ui/plant-form"
 import { useToast } from "@/hooks/use-toast"
-import { ArrowLeft, Leaf, Save, Calendar, Plus, CheckCircle, AlertTriangle, Trash2 } from "lucide-react"
+import { ArrowLeft, Leaf, Save, Trash2 } from "lucide-react"
 import { getPlant, updatePlant, deletePlant } from "@/lib/database"
 import type { Plant } from "@/lib/supabase"
 import { AddTaskForm } from '@/components/tasks/add-task-form'
 import { TaskService } from '@/lib/services/task.service'
 import type { TaskWithPlantInfo } from '@/lib/types/tasks'
-
-interface EditPlant {
-  name: string
-  scientific_name: string
-  latin_name: string
-  variety: string
-  color: string
-  height: string
-  plant_height: string
-  plants_per_sqm: string
-  sun_preference: 'full-sun' | 'partial-sun' | 'shade'
-  planting_date: string
-  expected_harvest_date: string
-  status: 'gezond' | 'aandacht_nodig' | 'ziek' | 'dood' | 'geoogst'
-  notes: string
-  care_instructions: string
-  watering_frequency: string
-  fertilizer_schedule: string
-  emoji: string
-}
-
 
 export default function EditPlantPage() {
   const router = useRouter()
@@ -45,81 +20,52 @@ export default function EditPlantPage() {
   const { toast } = useToast()
   
   const [plant, setPlant] = useState<Plant | null>(null)
-  const [editPlant, setEditPlant] = useState<EditPlant>({
-    name: '',
-    scientific_name: '',
-    latin_name: '',
-    variety: '',
-    color: '',
-    height: '',
-    plant_height: '',
-    plants_per_sqm: '',
-    sun_preference: 'full-sun',
-    planting_date: '',
-    expected_harvest_date: '',
-    status: 'gezond',
-    notes: '',
-    care_instructions: '',
-    watering_frequency: '',
-    fertilizer_schedule: '',
-    emoji: '🌸'
-  })
+  const [plantData, setPlantData] = useState<PlantFormData>(createInitialPlantFormData())
+  const [errors, setErrors] = useState<PlantFormErrors>({})
   const [loading, setLoading] = useState(true)
   const [saving, setSaving] = useState(false)
+  const [deleting, setDeleting] = useState(false)
   const [showAddTask, setShowAddTask] = useState(false)
   const [tasks, setTasks] = useState<TaskWithPlantInfo[]>([])
-  // Add loading state for individual tasks
-  const [updatingTasks, setUpdatingTasks] = useState<Set<string>>(new Set())
 
+  // Load plant data
   useEffect(() => {
-    async function loadPlant() {
+    const loadPlant = async () => {
       try {
-        const plantId = params.plantId as string
-        const plantData = await getPlant(plantId)
+        setLoading(true)
+        const plantData = await getPlant(params.plantId as string)
         
-        if (!plantData) {
-          toast({
-            title: "Plant niet gevonden",
-            description: "De plant kon niet worden gevonden.",
-            variant: "destructive",
+        if (plantData) {
+          setPlant(plantData)
+          
+          // Convert plant data to form data
+          setPlantData({
+            name: plantData.name,
+            color: plantData.color || "",
+            height: plantData.height?.toString() || "",
+            scientificName: plantData.scientific_name || "",
+            latinName: plantData.latin_name || "",
+            variety: plantData.variety || "",
+            plantColor: plantData.plant_color || "",
+            plantHeight: plantData.plant_height?.toString() || "",
+            plantsPerSqm: plantData.plants_per_sqm?.toString() || "4",
+            sunPreference: plantData.sun_preference || 'partial-sun',
+            plantingDate: plantData.planting_date || "",
+            expectedHarvestDate: plantData.expected_harvest_date || "",
+            status: plantData.status || "gezond",
+            notes: plantData.notes || "",
+            careInstructions: plantData.care_instructions || "",
+            wateringFrequency: plantData.watering_frequency?.toString() || "",
+            fertilizerSchedule: plantData.fertilizer_schedule || "",
+            emoji: plantData.emoji || "🌼",
+            isStandardFlower: false, // We don't store this in the database
           })
-          router.back()
-          return
-        }
-
-        setPlant(plantData)
-        setEditPlant({
-          name: plantData.name || '',
-          scientific_name: plantData.scientific_name || '',
-          latin_name: plantData.latin_name || '',
-          variety: plantData.variety || '',
-          color: plantData.color || '',
-          height: plantData.height?.toString() || '',
-          plant_height: plantData.plant_height?.toString() || '',
-          plants_per_sqm: plantData.plants_per_sqm?.toString() || '',
-          sun_preference: plantData.sun_preference || 'full-sun',
-          planting_date: plantData.planting_date || '',
-          expected_harvest_date: plantData.expected_harvest_date || '',
-          status: (plantData.status || 'gezond') as 'gezond' | 'aandacht_nodig' | 'ziek' | 'dood' | 'geoogst',
-          notes: plantData.notes || '',
-          care_instructions: plantData.care_instructions || '',
-          watering_frequency: plantData.watering_frequency?.toString() || '',
-          fertilizer_schedule: plantData.fertilizer_schedule || '',
-          emoji: plantData.emoji || '🌸'
-        })
-
-        // Load tasks for this plant
-        const { data: plantTasks, error: taskError } = await TaskService.getTasksForPlant(plantId)
-        if (taskError) {
-          console.error("Error loading tasks:", taskError)
-        } else {
-          setTasks(plantTasks)
         }
       } catch (error) {
-        console.error("Error loading plant:", error)
+        console.error('Error loading plant:', error)
         toast({
-          title: "Fout",
-          description: "Kon plant niet laden.",
+          title: "Fout bij laden",
+          description: "Kon de plant gegevens niet laden.",
           variant: "destructive",
         })
       } finally {
@@ -127,44 +73,98 @@ export default function EditPlantPage() {
       }
     }
 
-    loadPlant()
-  }, [params.plantId, toast, router])
+    const loadTasks = async () => {
+      try {
+        const { data: tasksData } = await TaskService.getTasksWithPlantInfo({ 
+          plant_id: params.plantId as string 
+        })
+        if (tasksData) {
+          setTasks(tasksData)
+        }
+      } catch (error) {
+        console.error('Error loading tasks:', error)
+      }
+    }
+
+    if (params.plantId) {
+      loadPlant()
+      loadTasks()
+    }
+  }, [params.plantId, toast])
+
+  const validateForm = (data: PlantFormData): PlantFormErrors => {
+    const newErrors: PlantFormErrors = {}
+
+    if (!data.name.trim()) {
+      newErrors.name = "Plantnaam is verplicht"
+    }
+
+    if (!data.color.trim()) {
+      newErrors.color = "Kleur is verplicht"
+    }
+
+    if (!data.height.trim()) {
+      newErrors.height = "Hoogte is verplicht"
+    } else if (isNaN(Number(data.height)) || Number(data.height) <= 0) {
+      newErrors.height = "Hoogte moet een geldig getal groter dan 0 zijn"
+    }
+
+    return newErrors
+  }
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
+    
     if (!plant) return
 
+    // Validate form
+    const newErrors = validateForm(plantData)
+    if (Object.keys(newErrors).length > 0) {
+      setErrors(newErrors)
+      return
+    }
+
     setSaving(true)
+    setErrors({})
+
     try {
-      await updatePlant(plant.id, {
-        name: editPlant.name,
-        scientific_name: editPlant.scientific_name || undefined,
-        latin_name: editPlant.latin_name || undefined,
-        variety: editPlant.variety || undefined,
-        color: editPlant.color || undefined,
-        height: editPlant.height ? Number.parseInt(editPlant.height) : undefined,
-        plant_height: editPlant.plant_height ? Number.parseInt(editPlant.plant_height) : undefined,
-        plants_per_sqm: editPlant.plants_per_sqm ? Number.parseInt(editPlant.plants_per_sqm) : undefined,
-        sun_preference: editPlant.sun_preference,
-        planting_date: editPlant.planting_date || undefined,
-        expected_harvest_date: editPlant.expected_harvest_date || undefined,
-        status: editPlant.status,
-        notes: editPlant.notes || undefined,
-        care_instructions: editPlant.care_instructions || undefined,
-        watering_frequency: editPlant.watering_frequency ? Number.parseInt(editPlant.watering_frequency) : undefined,
-        fertilizer_schedule: editPlant.fertilizer_schedule || undefined,
-        emoji: editPlant.emoji,
-      })
+      const updateData = {
+        name: plantData.name,
+        scientific_name: plantData.scientificName || undefined,
+        latin_name: plantData.latinName || undefined,
+        variety: plantData.variety || undefined,
+        color: plantData.color || undefined,
+        plant_color: plantData.plantColor || undefined,
+        height: plantData.height ? Number.parseInt(plantData.height) : undefined,
+        plant_height: plantData.plantHeight ? Number.parseInt(plantData.plantHeight) : undefined,
+        plants_per_sqm: plantData.plantsPerSqm ? Number.parseInt(plantData.plantsPerSqm) : undefined,
+        sun_preference: plantData.sunPreference,
+        planting_date: plantData.plantingDate || undefined,
+        expected_harvest_date: plantData.expectedHarvestDate || undefined,
+        status: plantData.status,
+        notes: plantData.notes || undefined,
+        care_instructions: plantData.careInstructions || undefined,
+        watering_frequency: plantData.wateringFrequency ? Number.parseInt(plantData.wateringFrequency) : undefined,
+        fertilizer_schedule: plantData.fertilizerSchedule || undefined,
+        emoji: plantData.emoji,
+      }
+
+      const result = await updatePlant(plant.id, updateData)
+      
+      if (!result) {
+        throw new Error('Failed to update plant')
+      }
 
       toast({
-        title: "Plant bijgewerkt!",
-        description: `Plant "${editPlant.name}" is succesvol bijgewerkt.`,
+        title: "Plant bijgewerkt",
+        description: `Plant "${plantData.name}" is succesvol bijgewerkt.`,
       })
-      router.push(`/plants/${plant.id}`)
+
+      router.push(`/gardens/${params.id}/plant-beds/${params.bedId}/plants`)
     } catch (error) {
-      console.error("Error updating plant:", error)
+      console.error('Error updating plant:', error)
       toast({
-        title: "Fout",
+        title: "Fout bij bijwerken",
         description: "Er ging iets mis bij het bijwerken van de plant.",
         variant: "destructive",
       })
@@ -173,103 +173,63 @@ export default function EditPlantPage() {
     }
   }
 
-  const handleTaskToggle = async (taskId: string, completed: boolean) => {
-    // Prevent multiple simultaneous updates of the same task
-    if (updatingTasks.has(taskId)) {
+  const handleDelete = async () => {
+    if (!plant) return
+
+    if (!confirm(`Weet je zeker dat je de plant "${plant.name}" wilt verwijderen?`)) {
       return
     }
 
+    setDeleting(true)
+
     try {
-      // Add task to updating set
-      setUpdatingTasks(prev => new Set(prev).add(taskId))
-
-      // Optimistic update - update the tasks state immediately for better UX
-      setTasks(prevTasks => 
-        prevTasks.map(task => 
-          task.id === taskId 
-            ? { ...task, completed, completed_at: completed ? new Date().toISOString() : undefined }
-            : task
-        )
-      )
-
-      const { error } = await TaskService.updateTask(taskId, { completed })
+      await deletePlant(plant.id)
       
-      if (error) {
-        console.error("Error updating task:", error)
-        // Revert optimistic update on error
-        if (plant) {
-          const { data: plantTasks, error: taskError } = await TaskService.getTasksForPlant(plant.id)
-          if (!taskError) {
-            setTasks(plantTasks)
-          }
-        }
-        toast({
-          title: "Fout",
-          description: "Kon taak niet bijwerken.",
-          variant: "destructive",
-        })
-        return
-      }
-
       toast({
-        title: completed ? "Taak voltooid!" : "Taak heropend",
-        description: completed ? "De taak is gemarkeerd als voltooid." : "De taak is heropend.",
+        title: "Plant verwijderd",
+        description: `Plant "${plant.name}" is succesvol verwijderd.`,
       })
+
+      router.push(`/gardens/${params.id}/plant-beds/${params.bedId}/plants`)
     } catch (error) {
-      console.error("Error updating task:", error)
-      // Revert optimistic update on error
-      if (plant) {
-        const { data: plantTasks, error: taskError } = await TaskService.getTasksForPlant(plant.id)
-        if (!taskError) {
-          setTasks(plantTasks)
-        }
-      }
+      console.error('Error deleting plant:', error)
       toast({
-        title: "Fout",
-        description: "Kon taak niet bijwerken.",
+        title: "Fout bij verwijderen",
+        description: "Er ging iets mis bij het verwijderen van de plant.",
         variant: "destructive",
       })
     } finally {
-      // Always remove task from updating set
-      setUpdatingTasks(prev => {
-        const newSet = new Set(prev)
-        newSet.delete(taskId)
-        return newSet
-      })
+      setDeleting(false)
     }
   }
 
-  const handleDeleteTask = async (taskId: string) => {
-    try {
-      await TaskService.deleteTask(taskId)
-      // Reload tasks
-      if (plant) {
-        const { data: plantTasks, error: taskError } = await TaskService.getTasksForPlant(plant.id)
-        if (!taskError) {
-          setTasks(plantTasks)
+  const handleTaskAdded = () => {
+    // Refresh tasks
+    const loadTasks = async () => {
+      try {
+        const { data: tasksData } = await TaskService.getTasksWithPlantInfo({ 
+          plant_id: params.plantId as string 
+        })
+        if (tasksData) {
+          setTasks(tasksData)
         }
+      } catch (error) {
+        console.error('Error loading tasks:', error)
       }
-      toast({
-        title: "Taak verwijderd",
-        description: "De taak is succesvol verwijderd.",
-      })
-    } catch (error) {
-      console.error("Error deleting task:", error)
-      toast({
-        title: "Fout",
-        description: "Kon taak niet verwijderen.",
-        variant: "destructive",
-      })
     }
+    loadTasks()
   }
 
   if (loading) {
     return (
-      <div className="min-h-screen bg-gradient-to-br from-green-50 to-blue-50 p-4">
-        <div className="max-w-4xl mx-auto">
-          <div className="text-center py-12">
-            <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-green-600 mx-auto"></div>
-            <p className="mt-4 text-gray-600">Plant laden...</p>
+      <div className="container mx-auto p-6">
+        <div className="animate-pulse space-y-6">
+          <div className="h-8 bg-gray-200 rounded w-1/4"></div>
+          <div className="h-4 bg-gray-200 rounded w-1/2"></div>
+          <div className="space-y-4">
+            <div className="h-10 bg-gray-200 rounded"></div>
+            <div className="h-10 bg-gray-200 rounded"></div>
+            <div className="h-10 bg-gray-200 rounded"></div>
           </div>
         </div>
       </div>
@@ -278,334 +238,120 @@ export default function EditPlantPage() {
 
   if (!plant) {
     return (
-      <div className="min-h-screen bg-gradient-to-br from-green-50 to-blue-50 p-4">
-        <div className="max-w-4xl mx-auto">
-          <div className="text-center py-12">
-            <p className="text-gray-600">Plant niet gevonden</p>
-          </div>
+      <div className="container mx-auto p-6">
+        <div className="text-center">
+          <h2 className="text-2xl font-bold text-gray-900 mb-4">Plant niet gevonden</h2>
+          <p className="text-gray-600 mb-6">De opgevraagde plant bestaat niet of is verwijderd.</p>
+          <Button asChild>
+            <Link href={`/gardens/${params.id}/plant-beds/${params.bedId}/plants`}>
+              <ArrowLeft className="h-4 w-4 mr-2" />
+              Terug naar planten
+            </Link>
+          </Button>
         </div>
       </div>
     )
   }
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-green-50 to-blue-50 p-4">
-      <div className="max-w-4xl mx-auto space-y-6">
-        {/* Header */}
-        <div className="flex items-center gap-4">
-          <Link 
-            href={`/plants/${plant.id}`}
-            className="flex items-center gap-2 text-gray-600 hover:text-gray-900"
-          >
-            <ArrowLeft className="h-5 w-5" />
-            Terug naar plant
-          </Link>
-          <div>
-            <h1 className="text-3xl font-bold text-gray-900">Plant Bewerken</h1>
-            <p className="text-gray-600">{plant.name}</p>
-          </div>
+    <div className="container mx-auto p-6 max-w-4xl">
+      {/* Back button */}
+      <Button asChild variant="ghost" className="mb-6">
+        <Link href={`/gardens/${params.id}/plant-beds/${params.bedId}/plants`}>
+          <ArrowLeft className="h-4 w-4 mr-2" />
+          Terug naar planten
+        </Link>
+      </Button>
+
+      {/* Header */}
+      <div className="mb-8">
+        <h1 className="text-3xl font-bold text-gray-900 mb-2 flex items-center gap-2">
+          <Leaf className="h-8 w-8 text-green-600" />
+          Plant Bewerken
+        </h1>
+        <div className="text-gray-600">
+          <p>{plant.name}</p>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        {/* Plant Form */}
+        <div className="lg:col-span-2">
+          <Card>
+            <CardHeader>
+              <CardTitle>Plant Details</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <PlantForm
+                data={plantData}
+                errors={errors}
+                onChange={setPlantData}
+                onSubmit={handleSubmit}
+                submitLabel="Wijzigingen opslaan"
+                isSubmitting={saving}
+                showAdvanced={true}
+              />
+            </CardContent>
+          </Card>
         </div>
 
-        <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-          {/* Plant Form */}
-          <div className="lg:col-span-2">
+        {/* Sidebar */}
+        <div className="space-y-6">
+          {/* Actions */}
+          <Card>
+            <CardHeader>
+              <CardTitle>Acties</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              <Button
+                onClick={() => setShowAddTask(true)}
+                className="w-full"
+                variant="outline"
+              >
+                Taak toevoegen
+              </Button>
+              
+              <Button 
+                onClick={handleDelete}
+                variant="destructive" 
+                className="w-full"
+                disabled={deleting}
+              >
+                <Trash2 className="h-4 w-4 mr-2" />
+                {deleting ? 'Verwijderen...' : 'Plant verwijderen'}
+              </Button>
+            </CardContent>
+          </Card>
+
+          {/* Tasks */}
+          {tasks.length > 0 && (
             <Card>
               <CardHeader>
-                <CardTitle className="flex items-center gap-2">
-                  <Leaf className="h-5 w-5 text-green-600" />
-                  Plant Informatie
-                </CardTitle>
+                <CardTitle>Taken ({tasks.length})</CardTitle>
               </CardHeader>
               <CardContent>
-                <form onSubmit={handleSubmit} className="space-y-6">
-                  <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
-                    <div className="space-y-2">
-                      <Label htmlFor="name">Bloemnaam *</Label>
-                      <FlowerSelector
-                        value={editPlant.name}
-                        onValueChange={(value) => {
-                          setEditPlant(prev => ({ ...prev, name: value }))
-                        }}
-                        placeholder="Zoek een bloem of typ een nieuwe naam..."
-                      />
+                <div className="space-y-2">
+                  {tasks.slice(0, 3).map((task) => (
+                    <div key={task.id} className="flex items-center gap-2 text-sm">
+                      <div className={`w-2 h-2 rounded-full ${
+                        task.completed ? 'bg-green-500' : 
+                        task.priority === 'high' ? 'bg-red-500' : 
+                        task.priority === 'medium' ? 'bg-yellow-500' : 'bg-gray-500'
+                      }`} />
+                      <span className={task.completed ? 'line-through text-gray-500' : ''}>
+                        {task.title}
+                      </span>
                     </div>
-
-                    <div className="space-y-2">
-                      <Label htmlFor="scientificName">Wetenschappelijke naam</Label>
-                      <Input
-                        id="scientificName"
-                        value={editPlant.scientific_name}
-                        onChange={(e) => setEditPlant(prev => ({ ...prev, scientific_name: e.target.value }))}
-                      />
-                    </div>
-
-                    <div className="space-y-2">
-                      <Label htmlFor="latinName">Latijnse naam</Label>
-                      <Input
-                        id="latinName"
-                        value={editPlant.latin_name}
-                        onChange={(e) => setEditPlant(prev => ({ ...prev, latin_name: e.target.value }))}
-                      />
-                    </div>
-
-                    <div className="space-y-2">
-                      <Label htmlFor="variety">Variëteit</Label>
-                      <Input
-                        id="variety"
-                        value={editPlant.variety}
-                        onChange={(e) => setEditPlant(prev => ({ ...prev, variety: e.target.value }))}
-                      />
-                    </div>
-
-                    <div className="space-y-2">
-                      <Label htmlFor="color">Bloem kleur</Label>
-                      <Input
-                        id="color"
-                        value={editPlant.color}
-                        onChange={(e) => setEditPlant(prev => ({ ...prev, color: e.target.value }))}
-                      />
-                    </div>
-
-                    <div className="space-y-2">
-                      <Label htmlFor="height">Hoogte (cm)</Label>
-                      <Input
-                        id="height"
-                        type="number"
-                        value={editPlant.height}
-                        onChange={(e) => setEditPlant(prev => ({ ...prev, height: e.target.value }))}
-                      />
-                    </div>
-
-                    <div className="space-y-2">
-                      <Label htmlFor="plantHeight">Plant hoogte (cm)</Label>
-                      <Input
-                        id="plantHeight"
-                        type="number"
-                        value={editPlant.plant_height}
-                        onChange={(e) => setEditPlant(prev => ({ ...prev, plant_height: e.target.value }))}
-                      />
-                    </div>
-
-                    <div className="space-y-2">
-                      <Label htmlFor="plantsPerSqm">Planten per m²</Label>
-                      <Input
-                        id="plantsPerSqm"
-                        type="number"
-                        value={editPlant.plants_per_sqm}
-                        onChange={(e) => setEditPlant(prev => ({ ...prev, plants_per_sqm: e.target.value }))}
-                      />
-                    </div>
-
-                    <div className="space-y-2">
-                      <Label htmlFor="sunPreference">Zonvoorkeur</Label>
-                      <Select
-                        value={editPlant.sun_preference}
-                        onValueChange={(value: 'full-sun' | 'partial-sun' | 'shade') =>
-                          setEditPlant(prev => ({ ...prev, sun_preference: value }))
-                        }
-                      >
-                        <SelectTrigger>
-                          <SelectValue />
-                        </SelectTrigger>
-                        <SelectContent>
-                          <SelectItem value="full-sun">☀️ Volle zon</SelectItem>
-                          <SelectItem value="partial-sun">⛅ Gedeeltelijke zon</SelectItem>
-                          <SelectItem value="shade">🌳 Schaduw</SelectItem>
-                        </SelectContent>
-                      </Select>
-                    </div>
-
-                    <div className="space-y-2">
-                      <Label htmlFor="status">Status</Label>
-                      <Select
-                        value={editPlant.status}
-                        onValueChange={(value: 'gezond' | 'aandacht_nodig' | 'ziek' | 'dood' | 'geoogst') =>
-                          setEditPlant(prev => ({ ...prev, status: value }))
-                        }
-                      >
-                        <SelectTrigger>
-                          <SelectValue />
-                        </SelectTrigger>
-                        <SelectContent>
-                                          <SelectItem value="gezond">🌱 Gezond</SelectItem>
-                <SelectItem value="aandacht_nodig">⚠️ Aandacht nodig</SelectItem>
-                <SelectItem value="ziek">🦠 Ziek</SelectItem>
-                <SelectItem value="dood">💀 Dood</SelectItem>
-                <SelectItem value="geoogst">🌾 Geoogst</SelectItem>
-                        </SelectContent>
-                      </Select>
-                    </div>
-
-                    <div className="space-y-2">
-                      <Label htmlFor="plantingDate">Plantdatum</Label>
-                      <Input
-                        id="plantingDate"
-                        type="date"
-                        value={editPlant.planting_date}
-                        onChange={(e) => setEditPlant(prev => ({ ...prev, planting_date: e.target.value }))}
-                      />
-                    </div>
-
-                    <div className="space-y-2">
-                      <Label htmlFor="expectedHarvestDate">Verwachte oogstdatum</Label>
-                      <Input
-                        id="expectedHarvestDate"
-                        type="date"
-                        value={editPlant.expected_harvest_date}
-                        onChange={(e) => setEditPlant(prev => ({ ...prev, expected_harvest_date: e.target.value }))}
-                      />
-                    </div>
-
-                    <div className="space-y-2">
-                      <Label htmlFor="wateringFrequency">Begieten frequentie (dagen)</Label>
-                      <Input
-                        id="wateringFrequency"
-                        type="number"
-                        value={editPlant.watering_frequency}
-                        onChange={(e) => setEditPlant(prev => ({ ...prev, watering_frequency: e.target.value }))}
-                      />
-                    </div>
-
-                    <div className="space-y-2">
-                      <Label htmlFor="emoji">Emoji</Label>
-                      <Input
-                        id="emoji"
-                        value={editPlant.emoji}
-                        onChange={(e) => setEditPlant(prev => ({ ...prev, emoji: e.target.value }))}
-                      />
-                    </div>
-                  </div>
-
-                  <div className="space-y-2">
-                    <Label htmlFor="fertilizerSchedule">Bemesting schema</Label>
-                    <Input
-                      id="fertilizerSchedule"
-                      value={editPlant.fertilizer_schedule}
-                      onChange={(e) => setEditPlant(prev => ({ ...prev, fertilizer_schedule: e.target.value }))}
-                    />
-                  </div>
-
-                  <div className="space-y-2">
-                    <Label htmlFor="careInstructions">Verzorgingsinstructies</Label>
-                    <Textarea
-                      id="careInstructions"
-                      value={editPlant.care_instructions}
-                      onChange={(e) => setEditPlant(prev => ({ ...prev, care_instructions: e.target.value }))}
-                      rows={3}
-                    />
-                  </div>
-
-                  <div className="space-y-2">
-                    <Label htmlFor="notes">Notities</Label>
-                    <Textarea
-                      id="notes"
-                      value={editPlant.notes}
-                      onChange={(e) => setEditPlant(prev => ({ ...prev, notes: e.target.value }))}
-                      rows={3}
-                    />
-                  </div>
-
-                  <div className="flex gap-4">
-                    <Button type="submit" disabled={saving}>
-                      <Save className="h-4 w-4 mr-2" />
-                      {saving ? 'Opslaan...' : 'Opslaan'}
-                    </Button>
-                    <Button type="button" variant="outline" onClick={() => router.back()}>
-                      Annuleren
-                    </Button>
-                  </div>
-                </form>
-              </CardContent>
-            </Card>
-          </div>
-
-          {/* Tasks Sidebar */}
-          <div className="space-y-6">
-            <Card>
-              <CardHeader>
-                <div className="flex items-center justify-between">
-                  <CardTitle className="flex items-center gap-2">
-                    <Calendar className="h-5 w-5 text-blue-600" />
-                    Taken
-                  </CardTitle>
-                  <Button
-                    size="sm"
-                    onClick={() => setShowAddTask(true)}
-                  >
-                    <Plus className="h-4 w-4 mr-1" />
-                    Toevoegen
-                  </Button>
+                  ))}
+                  {tasks.length > 3 && (
+                    <p className="text-xs text-gray-500">
+                      En {tasks.length - 3} meer...
+                    </p>
+                  )}
                 </div>
-              </CardHeader>
-              <CardContent>
-                {tasks.length === 0 ? (
-                  <p className="text-sm text-gray-500 text-center py-4">
-                    Geen taken voor deze plant
-                  </p>
-                ) : (
-                  <div className="space-y-2">
-                    {(() => {
-                      // Sort tasks: completed at bottom, active tasks by date
-                      const sortedTasks = [...tasks].sort((a, b) => {
-                        // 1. Completed tasks go to bottom
-                        if (a.completed !== b.completed) {
-                          return a.completed ? 1 : -1
-                        }
-                        
-                        // 2. Sort by due date
-                        return new Date(a.due_date).getTime() - new Date(b.due_date).getTime()
-                      })
-                      
-                      return sortedTasks.map((task) => (
-                      <div
-                        key={task.id}
-                        className={`p-3 rounded-lg border ${
-                          task.completed ? 'bg-green-50 border-green-200' : 'bg-white border-gray-200'
-                        }`}
-                      >
-                        <div className="flex items-start justify-between gap-2">
-                          <div className="flex items-start gap-2 flex-1">
-                            <button
-                              onClick={() => handleTaskToggle(task.id, !task.completed)}
-                              className="mt-0.5"
-                              disabled={updatingTasks.has(task.id)}
-                            >
-                              <CheckCircle
-                                className={`h-4 w-4 ${
-                                  task.completed ? 'text-green-600' : 
-                                  updatingTasks.has(task.id) ? 'text-gray-300' :
-                                  'text-gray-400 hover:text-green-600'
-                                }`}
-                              />
-                            </button>
-                            <div className="flex-1 min-w-0">
-                              <p className={`text-sm font-medium ${task.completed ? 'line-through text-gray-500' : ''}`}>
-                                {task.title}
-                              </p>
-                              <p className="text-xs text-gray-500">
-                                {new Date(task.due_date).toLocaleDateString('nl-NL')}
-                              </p>
-                              {task.description && (
-                                <p className="text-xs text-gray-600 mt-1">{task.description}</p>
-                              )}
-                            </div>
-                          </div>
-                          <Button
-                            variant="ghost"
-                            size="sm"
-                            onClick={() => handleDeleteTask(task.id)}
-                            className="text-red-600 hover:text-red-700 h-6 w-6 p-0"
-                          >
-                            <Trash2 className="h-3 w-3" />
-                          </Button>
-                        </div>
-                      </div>
-                    ))})()}
-                  </div>
-                )}
               </CardContent>
             </Card>
-          </div>
+          )}
         </div>
       </div>
 
@@ -613,15 +359,7 @@ export default function EditPlantPage() {
       <AddTaskForm
         isOpen={showAddTask}
         onClose={() => setShowAddTask(false)}
-        onTaskAdded={async () => {
-          setShowAddTask(false)
-          if (plant) {
-            const { data: plantTasks, error: taskError } = await TaskService.getTasksForPlant(plant.id)
-            if (!taskError) {
-              setTasks(plantTasks)
-            }
-          }
-        }}
+        onTaskAdded={handleTaskAdded}
         preselectedPlantId={plant.id}
       />
     </div>

--- a/app/gardens/[id]/plant-beds/[bedId]/plants/[plantId]/edit/page.tsx
+++ b/app/gardens/[id]/plant-beds/[bedId]/plants/[plantId]/edit/page.tsx
@@ -9,6 +9,7 @@ import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Textarea } from "@/components/ui/textarea"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { FlowerSelector } from "@/components/ui/flower-selector"
 import { useToast } from "@/hooks/use-toast"
 import { ArrowLeft, Leaf, Save, Calendar, Plus, CheckCircle, AlertTriangle, Trash2 } from "lucide-react"
 import { getPlant, updatePlant, deletePlant } from "@/lib/database"
@@ -320,11 +321,12 @@ export default function EditPlantPage() {
                   <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
                     <div className="space-y-2">
                       <Label htmlFor="name">Bloemnaam *</Label>
-                      <Input
-                        id="name"
+                      <FlowerSelector
                         value={editPlant.name}
-                        onChange={(e) => setEditPlant(prev => ({ ...prev, name: e.target.value }))}
-                        required
+                        onValueChange={(value) => {
+                          setEditPlant(prev => ({ ...prev, name: value }))
+                        }}
+                        placeholder="Zoek een bloem of typ een nieuwe naam..."
                       />
                     </div>
 

--- a/app/gardens/[id]/plant-beds/[bedId]/plants/new/page.tsx
+++ b/app/gardens/[id]/plant-beds/[bedId]/plants/new/page.tsx
@@ -5,57 +5,14 @@ import { useRouter, useParams } from "next/navigation"
 import Link from "next/link"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
-import { Input } from "@/components/ui/input"
-import { Label } from "@/components/ui/label"
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
-import { FlowerSelector } from "@/components/ui/flower-selector"
+import { PlantForm, PlantFormData, PlantFormErrors, createInitialPlantFormData } from "@/components/ui/plant-form"
 import { useToast } from "@/hooks/use-toast"
-import { ArrowLeft, Leaf, Plus, AlertCircle, Calendar, ChevronDown } from "lucide-react"
+import { ArrowLeft, Leaf } from "lucide-react"
 import { getGarden, getPlantBed, createPlant } from "@/lib/database"
 import type { Garden, PlantBedWithPlants } from "@/lib/supabase"
 import { AddTaskForm } from '@/components/tasks/add-task-form'
 import { TaskService } from '@/lib/services/task.service'
 import type { TaskWithPlantInfo } from '@/lib/types/tasks'
-
-// Standard flower types with emojis
-const STANDARD_FLOWERS = [
-  { name: 'Roos', emoji: '🌹', color: '#FF69B4' },
-  { name: 'Tulp', emoji: '🌷', color: '#FF4500' },
-  { name: 'Zonnebloem', emoji: '🌻', color: '#FFD700' },
-  { name: 'Lavendel', emoji: '🪻', color: '#9370DB' },
-  { name: 'Dahlia', emoji: '🌺', color: '#FF1493' },
-  { name: 'Chrysant', emoji: '🌼', color: '#FFA500' },
-  { name: 'Narcis', emoji: '🌻', color: '#FFFF00' },
-  { name: 'Iris', emoji: '🌸', color: '#4B0082' },
-  { name: 'Petunia', emoji: '🌺', color: '#FF6B6B' },
-  { name: 'Begonia', emoji: '🌸', color: '#FF8C69' },
-  { name: 'Lelie', emoji: '🌺', color: '#FF69B4' },
-  { name: 'Anjer', emoji: '🌸', color: '#FF1493' },
-]
-
-const DEFAULT_FLOWER_EMOJI = '🌼'
-
-interface NewPlant {
-  name: string
-  scientificName: string
-  latinName: string
-  variety: string
-  color: string
-  plantColor: string
-  height: string
-  plantHeight: string
-  plantsPerSqm: string
-  sunPreference: 'full-sun' | 'partial-sun' | 'shade'
-  plantingDate: string
-  expectedHarvestDate: string
-  status: "gezond" | "aandacht_nodig" | "ziek" | "dood" | "geoogst"
-  notes: string
-  careInstructions: string
-  wateringFrequency: string
-  fertilizerSchedule: string
-  emoji: string
-  isStandardFlower: boolean
-}
 
 export default function NewPlantPage() {
   const router = useRouter()
@@ -65,9 +22,10 @@ export default function NewPlantPage() {
   const [garden, setGarden] = React.useState<Garden | null>(null)
   const [plantBed, setPlantBed] = React.useState<PlantBedWithPlants | null>(null)
   const [loading, setLoading] = React.useState(false)
-  const [errors, setErrors] = React.useState<Record<string, string>>({})
+  const [errors, setErrors] = React.useState<PlantFormErrors>({})
   const [showAddTask, setShowAddTask] = React.useState(false)
   const [createdPlantId, setCreatedPlantId] = React.useState<string | null>(null)
+  const [plantData, setPlantData] = React.useState<PlantFormData>(createInitialPlantFormData())
 
   // Clear any dialog states that might be stuck
   React.useEffect(() => {
@@ -84,28 +42,6 @@ export default function NewPlantPage() {
     }
   }, [])
 
-  const [newPlant, setNewPlant] = React.useState<NewPlant>({
-    name: "",
-    scientificName: "",
-    latinName: "",
-    variety: "",
-    color: "",
-    plantColor: "",
-    height: "",
-    plantHeight: "",
-    plantsPerSqm: "4",
-    sunPreference: 'partial-sun',
-    plantingDate: "",
-    expectedHarvestDate: "",
-    status: "gezond",
-    notes: "",
-    careInstructions: "",
-    wateringFrequency: "",
-    fertilizerSchedule: "",
-    emoji: DEFAULT_FLOWER_EMOJI,
-    isStandardFlower: false,
-  })
-
   React.useEffect(() => {
     const loadData = async () => {
       try {
@@ -113,78 +49,104 @@ export default function NewPlantPage() {
           getGarden(params.id as string),
           getPlantBed(params.bedId as string),
         ])
+        
         setGarden(gardenData)
         setPlantBed(plantBedData)
       } catch (error) {
-        console.error("Error loading data:", error)
+        console.error('Error loading data:', error)
         toast({
-          title: "Fout",
-          description: "Kon gegevens niet laden.",
+          title: "Fout bij laden",
+          description: "Kon de gegevens niet laden. Probeer het opnieuw.",
           variant: "destructive",
         })
       }
     }
 
-    loadData()
+    if (params.id && params.bedId) {
+      loadData()
+    }
   }, [params.id, params.bedId, toast])
 
-  const validateForm = () => {
-    const nextErrors: Record<string, string> = {}
+  const validateForm = (data: PlantFormData): PlantFormErrors => {
+    const newErrors: PlantFormErrors = {}
 
-    if (!newPlant.name.trim()) nextErrors.name = "Plantnaam is verplicht"
+    if (!data.name.trim()) {
+      newErrors.name = "Plantnaam is verplicht"
+    }
 
-    setErrors(nextErrors)
-    return Object.keys(nextErrors).length === 0
+    if (!data.color.trim()) {
+      newErrors.color = "Kleur is verplicht"
+    }
+
+    if (!data.height.trim()) {
+      newErrors.height = "Hoogte is verplicht"
+    } else if (isNaN(Number(data.height)) || Number(data.height) <= 0) {
+      newErrors.height = "Hoogte moet een geldig getal groter dan 0 zijn"
+    }
+
+    return newErrors
   }
 
-  async function handleSubmit(e: React.FormEvent) {
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
-    if (!validateForm() || !plantBed) {
+
+    if (!garden || !plantBed) {
       toast({
-        title: "Formulier onvolledig",
-        description: "Controleer de gemarkeerde velden en probeer opnieuw.",
+        title: "Fout",
+        description: "Tuin of plantvak gegevens zijn niet geladen.",
         variant: "destructive",
       })
       return
     }
 
+    // Validate form
+    const newErrors = validateForm(plantData)
+    if (Object.keys(newErrors).length > 0) {
+      setErrors(newErrors)
+      return
+    }
+
     setLoading(true)
+    setErrors({})
+
     try {
       const createdPlant = await createPlant({
         plant_bed_id: plantBed.id,
-        name: newPlant.name,
-        scientific_name: newPlant.scientificName || undefined,
-        latin_name: newPlant.latinName || undefined,
-        variety: newPlant.variety || undefined,
-        color: newPlant.color || undefined,
-        plant_color: newPlant.plantColor || undefined,
-        height: newPlant.height ? Number.parseInt(newPlant.height) : undefined,
-        plant_height: newPlant.plantHeight ? Number.parseInt(newPlant.plantHeight) : undefined,
-        plants_per_sqm: newPlant.plantsPerSqm ? Number.parseInt(newPlant.plantsPerSqm) : undefined,
-        sun_preference: newPlant.sunPreference,
-        planting_date: newPlant.plantingDate || undefined,
-        expected_harvest_date: newPlant.expectedHarvestDate || undefined,
-        status: newPlant.status,
-        notes: newPlant.notes || undefined,
-        care_instructions: newPlant.careInstructions || undefined,
-        watering_frequency: newPlant.wateringFrequency ? Number.parseInt(newPlant.wateringFrequency) : undefined,
-        fertilizer_schedule: newPlant.fertilizerSchedule || undefined,
-        emoji: newPlant.emoji,
+        name: plantData.name,
+        scientific_name: plantData.scientificName || undefined,
+        latin_name: plantData.latinName || undefined,
+        variety: plantData.variety || undefined,
+        color: plantData.color || undefined,
+        plant_color: plantData.plantColor || undefined,
+        height: plantData.height ? Number.parseInt(plantData.height) : undefined,
+        plant_height: plantData.plantHeight ? Number.parseInt(plantData.plantHeight) : undefined,
+        plants_per_sqm: plantData.plantsPerSqm ? Number.parseInt(plantData.plantsPerSqm) : undefined,
+        sun_preference: plantData.sunPreference,
+        planting_date: plantData.plantingDate || undefined,
+        expected_harvest_date: plantData.expectedHarvestDate || undefined,
+        status: plantData.status,
+        notes: plantData.notes || undefined,
+        care_instructions: plantData.careInstructions || undefined,
+        watering_frequency: plantData.wateringFrequency ? Number.parseInt(plantData.wateringFrequency) : undefined,
+        fertilizer_schedule: plantData.fertilizerSchedule || undefined,
+        emoji: plantData.emoji,
       })
 
       if (createdPlant) {
         setCreatedPlantId(createdPlant.id)
       }
+      
       toast({
         title: "Plant toegevoegd!",
-        description: `Plant "${newPlant.name}" is succesvol toegevoegd aan ${plantBed.name}.`,
+        description: `Plant "${plantData.name}" is succesvol toegevoegd aan ${plantBed.name}.`,
       })
+      
       router.push(`/gardens/${garden?.id}/plant-beds/${plantBed.id}/plants`)
-    } catch (err) {
-      console.error("Error creating plant:", err)
+    } catch (error) {
+      console.error('Error creating plant:', error)
       toast({
-        title: "Fout",
-        description: "Er ging iets mis bij het toevoegen van de plant.",
+        title: "Fout bij toevoegen",
+        description: "Er ging iets mis bij het toevoegen van de plant. Probeer het opnieuw.",
         variant: "destructive",
       })
     } finally {
@@ -193,491 +155,89 @@ export default function NewPlantPage() {
   }
 
   const handleReset = () => {
-    setNewPlant({
-      name: "",
-      scientificName: "",
-      latinName: "",
-      variety: "",
-      color: "",
-      plantColor: "",
-      height: "",
-      plantHeight: "",
-      plantsPerSqm: "4",
-      sunPreference: 'partial-sun',
-      plantingDate: "",
-      expectedHarvestDate: "",
-      status: "gezond",
-      notes: "",
-      careInstructions: "",
-      wateringFrequency: "",
-      fertilizerSchedule: "",
-      emoji: DEFAULT_FLOWER_EMOJI,
-      isStandardFlower: false,
-    })
+    setPlantData(createInitialPlantFormData())
     setErrors({})
+  }
+
+  const handleTaskAdd = (plantId?: string) => {
+    if (createdPlantId) {
+      setShowAddTask(true)
+    } else {
+      toast({
+        title: "Geen plant geselecteerd",
+        description: "Voeg eerst een plant toe voordat je een taak kunt aanmaken.",
+        variant: "destructive",
+      })
+    }
+  }
+
+  const handleTaskAdded = () => {
+    // Task added successfully, could refresh tasks or show confirmation
   }
 
   if (!garden || !plantBed) {
     return (
       <div className="container mx-auto p-6">
         <div className="animate-pulse space-y-6">
-          <div className="h-8 bg-gray-200 rounded w-1/3"></div>
-          <div className="h-64 bg-gray-200 rounded"></div>
+          <div className="h-8 bg-gray-200 rounded w-1/4"></div>
+          <div className="h-4 bg-gray-200 rounded w-1/2"></div>
+          <div className="space-y-4">
+            <div className="h-10 bg-gray-200 rounded"></div>
+            <div className="h-10 bg-gray-200 rounded"></div>
+            <div className="h-10 bg-gray-200 rounded"></div>
+          </div>
         </div>
       </div>
     )
   }
 
   return (
-    <div className="container mx-auto space-y-6 p-6">
-      <div className="flex flex-wrap items-center justify-between gap-4">
-        <div className="flex items-center gap-4">
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={() => router.push(`/gardens/${garden.id}/plant-beds/${plantBed.id}/plants`)}
-            className="flex items-center gap-2"
-          >
-            <ArrowLeft className="h-4 w-4" />
-            {plantBed.name} - Planten
-          </Button>
-
-          <div>
-            <h1 className="flex items-center gap-2 text-2xl font-bold md:text-3xl">
-              <Plus className="h-7 w-7 text-green-600" />
-              Nieuwe Plant
-            </h1>
-            <p className="text-muted-foreground">Voeg een nieuwe plant toe aan {plantBed.name}</p>
-          </div>
-        </div>
-
-        <Link href="/plant-beds/new">
-          <Button className="bg-green-600 hover:bg-green-700">
-            <Plus className="h-4 w-4 mr-2" />
-            Plantvak Toevoegen
-          </Button>
+    <div className="container mx-auto p-6 max-w-4xl">
+      {/* Back button */}
+      <Button asChild variant="ghost" className="mb-6">
+        <Link href={`/gardens/${garden.id}/plant-beds/${plantBed.id}/plants`}>
+          <ArrowLeft className="h-4 w-4 mr-2" />
+          Terug naar planten
         </Link>
-      </div>
+      </Button>
 
-      <div className="grid grid-cols-1 gap-6 lg:grid-cols-3">
-        <div className="lg:col-span-2">
-          <Card>
-            <CardHeader>
-              <CardTitle className="flex items-center gap-2">
-                <Leaf className="h-5 w-5 text-green-600" />
-                Plant informatie
-              </CardTitle>
-            </CardHeader>
-
-            <CardContent>
-              <form onSubmit={handleSubmit} onReset={handleReset} className="space-y-6">
-                <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
-                  <div className="space-y-2">
-                    <Label htmlFor="name">Bloemnaam *</Label>
-                    <FlowerSelector
-                      value={newPlant.name}
-                      onValueChange={(value) => {
-                        setNewPlant((p) => ({
-                          ...p,
-                          name: value,
-                        }))
-                      }}
-                      placeholder="Zoek een bloem of typ een nieuwe naam..."
-                    />
-                    {errors.name && (
-                      <div className="flex items-center gap-1 text-destructive text-sm">
-                        <AlertCircle className="h-4 w-4" />
-                        {errors.name}
-                      </div>
-                    )}
-                  </div>
-
-                  <div className="space-y-2">
-                    <Label htmlFor="scientificName">Wetenschappelijke naam</Label>
-                    <Input
-                      id="scientificName"
-                      placeholder="Bijv. Solanum lycopersicum"
-                      value={newPlant.scientificName}
-                      onChange={(e) =>
-                        setNewPlant((p) => ({
-                          ...p,
-                          scientificName: e.target.value,
-                        }))
-                      }
-                      autoComplete="off"
-                    />
-                  </div>
-
-                  <div className="space-y-2">
-                    <Label htmlFor="latinName">Latijnse naam</Label>
-                    <Input
-                      id="latinName"
-                      placeholder="Bijv. Rosa gallica"
-                      value={newPlant.latinName}
-                      onChange={(e) =>
-                        setNewPlant((p) => ({
-                          ...p,
-                          latinName: e.target.value,
-                        }))
-                      }
-                      autoComplete="off"
-                    />
-                  </div>
-
-                  <div className="space-y-2">
-                    <Label htmlFor="variety">Variëteit</Label>
-                    <Input
-                      id="variety"
-                      placeholder="Bijv. Cherry tomaat, Genovese basilicum"
-                      value={newPlant.variety}
-                      onChange={(e) =>
-                        setNewPlant((p) => ({
-                          ...p,
-                          variety: e.target.value,
-                        }))
-                      }
-                      autoComplete="off"
-                    />
-                  </div>
-
-                  <div className="space-y-2">
-                    <Label htmlFor="color">Kleur</Label>
-                    <Input
-                      id="color"
-                      placeholder="Bijv. Rood, Geel, Wit"
-                      value={newPlant.color}
-                      onChange={(e) =>
-                        setNewPlant((p) => ({
-                          ...p,
-                          color: e.target.value,
-                        }))
-                      }
-                      autoComplete="off"
-                    />
-                  </div>
-
-                  <div className="space-y-2">
-                    <Label htmlFor="plantColor">Plant kleur</Label>
-                    <Input
-                      id="plantColor"
-                      placeholder="Bijv. Groen, Donkergroen"
-                      value={newPlant.plantColor}
-                      onChange={(e) =>
-                        setNewPlant((p) => ({
-                          ...p,
-                          plantColor: e.target.value,
-                        }))
-                      }
-                      autoComplete="off"
-                    />
-                  </div>
-
-                  <div className="space-y-2">
-                    <Label htmlFor="height">Hoogte (cm)</Label>
-                    <Input
-                      id="height"
-                      type="number"
-                      placeholder="Bijv. 150"
-                      value={newPlant.height}
-                      onChange={(e) =>
-                        setNewPlant((p) => ({
-                          ...p,
-                          height: e.target.value,
-                        }))
-                      }
-                      autoComplete="off"
-                    />
-                  </div>
-
-                  <div className="space-y-2">
-                    <Label htmlFor="plantHeight">Plant hoogte (cm)</Label>
-                    <Input
-                      id="plantHeight"
-                      type="number"
-                      placeholder="Bijv. 80"
-                      value={newPlant.plantHeight}
-                      onChange={(e) =>
-                        setNewPlant((p) => ({
-                          ...p,
-                          plantHeight: e.target.value,
-                        }))
-                      }
-                      autoComplete="off"
-                    />
-                  </div>
-
-                  <div className="space-y-2">
-                    <Label htmlFor="plantsPerSqm">Planten per m²</Label>
-                    <Input
-                      id="plantsPerSqm"
-                      type="number"
-                      placeholder="Bijv. 4"
-                      value={newPlant.plantsPerSqm}
-                      onChange={(e) =>
-                        setNewPlant((p) => ({
-                          ...p,
-                          plantsPerSqm: e.target.value,
-                        }))
-                      }
-                      autoComplete="off"
-                    />
-                  </div>
-
-                  <div className="space-y-2">
-                    <Label htmlFor="sunPreference">Zonvoorkeur</Label>
-                    <Select
-                      value={newPlant.sunPreference}
-                      onValueChange={(value: 'full-sun' | 'partial-sun' | 'shade') =>
-                        setNewPlant((p) => ({
-                          ...p,
-                          sunPreference: value,
-                        }))
-                      }
-                    >
-                      <SelectTrigger>
-                        <SelectValue placeholder="Selecteer zonvoorkeur" />
-                      </SelectTrigger>
-                      <SelectContent>
-                        <SelectItem value="full-sun">☀️ Volle zon</SelectItem>
-                        <SelectItem value="partial-sun">⛅ Gedeeltelijke zon</SelectItem>
-                        <SelectItem value="shade">🌳 Schaduw</SelectItem>
-                      </SelectContent>
-                    </Select>
-                  </div>
-
-                  <div className="space-y-2">
-                    <Label htmlFor="status">Status</Label>
-                    <Select
-                      value={newPlant.status}
-                      onValueChange={(value: "gezond" | "aandacht_nodig" | "ziek" | "dood" | "geoogst") =>
-                        setNewPlant((p) => ({
-                          ...p,
-                          status: value,
-                        }))
-                      }
-                    >
-                      <SelectTrigger>
-                        <SelectValue placeholder="Selecteer status" />
-                      </SelectTrigger>
-                      <SelectContent>
-                        <SelectItem value="gezond">🌱 Gezond</SelectItem>
-                        <SelectItem value="aandacht_nodig">⚠️ Aandacht nodig</SelectItem>
-                        <SelectItem value="ziek">🦠 Ziek</SelectItem>
-                        <SelectItem value="dood">💀 Dood</SelectItem>
-                        <SelectItem value="geoogst">🌾 Geoogst</SelectItem>
-                      </SelectContent>
-                    </Select>
-                  </div>
-
-                  <div className="space-y-2">
-                    <Label htmlFor="plantingDate">Plantdatum</Label>
-                    <Input
-                      id="plantingDate"
-                      type="date"
-                      value={newPlant.plantingDate}
-                      onChange={(e) =>
-                        setNewPlant((p) => ({
-                          ...p,
-                          plantingDate: e.target.value,
-                        }))
-                      }
-                      autoComplete="off"
-                    />
-                  </div>
-
-                  <div className="space-y-2">
-                    <Label htmlFor="expectedHarvestDate">Verwachte oogstdatum</Label>
-                    <Input
-                      id="expectedHarvestDate"
-                      type="date"
-                      value={newPlant.expectedHarvestDate}
-                      onChange={(e) =>
-                        setNewPlant((p) => ({
-                          ...p,
-                          expectedHarvestDate: e.target.value,
-                        }))
-                      }
-                      autoComplete="off"
-                    />
-                  </div>
-
-                  <div className="space-y-2">
-                    <Label htmlFor="wateringFrequency">Bewatering (keer per week)</Label>
-                    <Input
-                      id="wateringFrequency"
-                      type="number"
-                      placeholder="Bijv. 3"
-                      value={newPlant.wateringFrequency}
-                      onChange={(e) =>
-                        setNewPlant((p) => ({
-                          ...p,
-                          wateringFrequency: e.target.value,
-                        }))
-                      }
-                      autoComplete="off"
-                    />
-                  </div>
-
-                  <div className="space-y-2">
-                    <Label htmlFor="fertilizerSchedule">Bemestingsschema</Label>
-                    <Input
-                      id="fertilizerSchedule"
-                      placeholder="Bijv. Elke 2 weken"
-                      value={newPlant.fertilizerSchedule}
-                      onChange={(e) =>
-                        setNewPlant((p) => ({
-                          ...p,
-                          fertilizerSchedule: e.target.value,
-                        }))
-                      }
-                      autoComplete="off"
-                    />
-                  </div>
-
-                  <div className="space-y-2">
-                    <Label htmlFor="emoji">Emoji</Label>
-                    <div className="flex items-center gap-2 p-2 border rounded-md bg-gray-50">
-                      <span className="text-2xl">{newPlant.emoji}</span>
-                      <span className="text-sm text-gray-600">
-                        {newPlant.isStandardFlower 
-                          ? "Automatisch toegewezen voor standaard bloem" 
-                          : "Standaard emoji voor aangepaste bloem"}
-                      </span>
-                    </div>
-                  </div>
-                </div>
-
-                <div className="space-y-2">
-                  <Label htmlFor="careInstructions">Verzorgingsinstructies</Label>
-                  <textarea
-                    id="careInstructions"
-                    rows={3}
-                    className="w-full resize-none rounded-md border bg-background p-2 text-sm shadow-sm outline-none focus:ring-2 focus:ring-ring"
-                    placeholder="Speciale verzorgingsinstructies..."
-                    value={newPlant.careInstructions}
-                    onChange={(e) =>
-                      setNewPlant((p) => ({
-                        ...p,
-                        careInstructions: e.target.value,
-                      }))
-                    }
-                    autoComplete="off"
-                  />
-                </div>
-
-                <div className="space-y-2">
-                  <Label htmlFor="notes">Notities</Label>
-                  <textarea
-                    id="notes"
-                    rows={4}
-                    className="w-full resize-none rounded-md border bg-background p-2 text-sm shadow-sm outline-none focus:ring-2 focus:ring-ring"
-                    placeholder="Aanvullende notities, observaties, etc..."
-                    value={newPlant.notes}
-                    onChange={(e) =>
-                      setNewPlant((p) => ({
-                        ...p,
-                        notes: e.target.value,
-                      }))
-                    }
-                    autoComplete="off"
-                  />
-                </div>
-
-                <div className="flex gap-3">
-                  <Button type="submit" disabled={loading}>
-                    {loading ? "Opslaan…" : "Plant Toevoegen"}
-                  </Button>
-                  <Button type="reset" variant="outline" disabled={loading}>
-                    Reset
-                  </Button>
-                </div>
-              </form>
-            </CardContent>
-          </Card>
+      {/* Header */}
+      <div className="mb-8">
+        <h1 className="text-3xl font-bold text-gray-900 mb-2 flex items-center gap-2">
+          <Leaf className="h-8 w-8 text-green-600" />
+          Nieuwe Plant Toevoegen
+        </h1>
+        <div className="text-gray-600">
+          <p><strong>Tuin:</strong> {garden.name}</p>
+          <p><strong>Plantvak:</strong> {plantBed.name}</p>
         </div>
-
-        <aside className="space-y-4">
-          {createdPlantId && (
-            <Card>
-              <CardHeader>
-                <div className="flex items-center justify-between">
-                  <CardTitle className="flex items-center gap-2">
-                    <Calendar className="h-4 w-4 text-blue-600" />
-                    Taken Toevoegen
-                  </CardTitle>
-                  <Button
-                    size="sm"
-                    onClick={() => setShowAddTask(true)}
-                  >
-                    <Plus className="h-4 w-4 mr-1" />
-                    Taak
-                  </Button>
-                </div>
-              </CardHeader>
-              <CardContent className="text-sm leading-relaxed">
-                <p>
-                  Plant succesvol aangemaakt! Je kunt nu taken toevoegen voor deze plant.
-                </p>
-              </CardContent>
-            </Card>
-          )}
-
-          <Card>
-            <CardHeader>
-              <CardTitle>Tips</CardTitle>
-            </CardHeader>
-            <CardContent className="text-sm leading-relaxed">
-              <p>
-                • Geef een duidelijke plantnaam op. <br />• Vul plantdatum in voor groei tracking. <br />• Stel de
-                juiste status in. <br />• Noteer speciale verzorgingsinstructies.
-              </p>
-            </CardContent>
-          </Card>
-
-          <Card>
-            <CardHeader>
-              <CardTitle className="flex items-center gap-2">
-                <Calendar className="h-4 w-4" />
-                Plantvak Info
-              </CardTitle>
-            </CardHeader>
-            <CardContent className="text-sm leading-relaxed">
-              <div className="space-y-2">
-                <div>
-                  <strong>Plantvak:</strong> {plantBed.name}
-                </div>
-                <div>
-                  <strong>ID:</strong> {plantBed.id}
-                </div>
-                <div>
-                  <strong>Locatie:</strong> {plantBed.location}
-                </div>
-                {plantBed.sun_exposure && (
-                  <div>
-                    <strong>Zonligging:</strong> {plantBed.sun_exposure}
-                  </div>
-                )}
-                <div>
-                  <strong>Huidige planten:</strong> {plantBed.plants.length}
-                </div>
-              </div>
-            </CardContent>
-          </Card>
-        </aside>
       </div>
+
+      {/* Plant Form */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Plant Details</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <PlantForm
+            data={plantData}
+            errors={errors}
+            onChange={setPlantData}
+            onSubmit={handleSubmit}
+            onReset={handleReset}
+            submitLabel="Plant toevoegen"
+            isSubmitting={loading}
+            showAdvanced={true}
+          />
+        </CardContent>
+      </Card>
 
       {/* Add Task Dialog */}
       {createdPlantId && (
         <AddTaskForm
           isOpen={showAddTask}
           onClose={() => setShowAddTask(false)}
-          onTaskAdded={() => {
-            setShowAddTask(false)
-            toast({
-              title: "Taak toegevoegd!",
-              description: "De taak is succesvol toegevoegd aan de plant.",
-            })
-          }}
+          onTaskAdded={handleTaskAdded}
           preselectedPlantId={createdPlantId}
         />
       )}

--- a/app/gardens/[id]/plant-beds/[bedId]/plants/new/page.tsx
+++ b/app/gardens/[id]/plant-beds/[bedId]/plants/new/page.tsx
@@ -8,6 +8,7 @@ import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { FlowerSelector } from "@/components/ui/flower-selector"
 import { useToast } from "@/hooks/use-toast"
 import { ArrowLeft, Leaf, Plus, AlertCircle, Calendar, ChevronDown } from "lucide-react"
 import { getGarden, getPlantBed, createPlant } from "@/lib/database"
@@ -273,76 +274,16 @@ export default function NewPlantPage() {
                 <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
                   <div className="space-y-2">
                     <Label htmlFor="name">Bloemnaam *</Label>
-                    <div className="relative">
-                      <Input
-                        id="name"
-                        placeholder="Typ een nieuwe bloem of kies uit de lijst..."
-                        value={newPlant.name}
-                        onChange={(e) => {
-                          const value = e.target.value
-                          setNewPlant((p) => ({
-                            ...p,
-                            name: value,
-                          }))
-                          
-                          // Check if it matches a standard flower
-                          const selectedFlower = STANDARD_FLOWERS.find(f => 
-                            f.name.toLowerCase() === value.toLowerCase()
-                          )
-                          if (selectedFlower) {
-                            setNewPlant((p) => ({
-                              ...p,
-                              name: value,
-                              emoji: selectedFlower.emoji,
-                              color: selectedFlower.color,
-                              isStandardFlower: true,
-                            }))
-                          } else {
-                            setNewPlant((p) => ({
-                              ...p,
-                              name: value,
-                              emoji: p.emoji === DEFAULT_FLOWER_EMOJI ? DEFAULT_FLOWER_EMOJI : p.emoji,
-                              isStandardFlower: false,
-                            }))
-                          }
-                        }}
-                        className={`${errors.name ? "border-destructive" : ""} pr-8`}
-                        required
-                        autoComplete="off"
-                      />
-                      <ChevronDown className="absolute right-2 top-1/2 transform -translate-y-1/2 h-4 w-4 text-gray-400 pointer-events-none" />
-                      {/* Show suggestions only when typing and there's input */}
-                      {newPlant.name && newPlant.name.length > 0 && (
-                        <div className="absolute z-10 w-full mt-1 bg-white border border-gray-300 rounded-md shadow-lg max-h-60 overflow-auto">
-                          {STANDARD_FLOWERS
-                            .filter(flower => 
-                              flower.name.toLowerCase().includes(newPlant.name.toLowerCase())
-                            )
-                            .slice(0, 5)
-                            .map((flower) => (
-                              <div
-                                key={flower.name}
-                                className="px-3 py-2 cursor-pointer hover:bg-gray-100 flex items-center gap-2"
-                                onClick={() => {
-                                  setNewPlant((p) => ({
-                                    ...p,
-                                    name: flower.name,
-                                    emoji: flower.emoji,
-                                    color: flower.color,
-                                    isStandardFlower: true,
-                                  }))
-                                }}
-                              >
-                                <span>{flower.emoji}</span>
-                                <span>{flower.name}</span>
-                              </div>
-                            ))}
-                        </div>
-                      )}
-                    </div>
-                    <p className="text-xs text-gray-500">
-                      Tip: Begin te typen om uit standaard bloemen te kiezen, of typ een eigen naam
-                    </p>
+                    <FlowerSelector
+                      value={newPlant.name}
+                      onValueChange={(value) => {
+                        setNewPlant((p) => ({
+                          ...p,
+                          name: value,
+                        }))
+                      }}
+                      placeholder="Zoek een bloem of typ een nieuwe naam..."
+                    />
                     {errors.name && (
                       <div className="flex items-center gap-1 text-destructive text-sm">
                         <AlertCircle className="h-4 w-4" />

--- a/app/gardens/[id]/plantvak-view/[bedId]/page.tsx
+++ b/app/gardens/[id]/plantvak-view/[bedId]/page.tsx
@@ -8,7 +8,7 @@ import { Badge } from "@/components/ui/badge"
 import { Input } from "@/components/ui/input"
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
-import { FlowerSelector } from "@/components/ui/flower-selector"
+
 import { Textarea } from "@/components/ui/textarea"
 import {
   Grid3X3,
@@ -1680,16 +1680,75 @@ export default function PlantBedViewPage() {
                   <label htmlFor="name" className="text-sm font-medium">
                     Bloemnaam *
                   </label>
-                  <FlowerSelector
-                    value={newFlower.name}
-                    onValueChange={(value) => {
-                      setNewFlower(prev => ({
-                        ...prev,
-                        name: value,
-                      }))
-                    }}
-                    placeholder="Zoek een bloem of typ een nieuwe naam..."
-                  />
+                  <div className="relative">
+                    <Input
+                      id="name"
+                      placeholder="Typ een nieuwe bloem of kies uit de lijst..."
+                      value={newFlower.name}
+                      onChange={(e) => {
+                        const value = e.target.value
+                        setNewFlower(prev => ({
+                          ...prev,
+                          name: value,
+                        }))
+                        
+                        // Check if it matches a standard flower
+                        const selectedFlower = STANDARD_FLOWERS.find(f => 
+                          f.name.toLowerCase() === value.toLowerCase()
+                        )
+                        if (selectedFlower) {
+                          setNewFlower(prev => ({
+                            ...prev,
+                            name: value,
+                            emoji: selectedFlower.emoji,
+                            color: selectedFlower.color,
+                            isStandardFlower: true,
+                          }))
+                        } else {
+                          setNewFlower(prev => ({
+                            ...prev,
+                            name: value,
+                            emoji: prev.emoji === DEFAULT_FLOWER_EMOJI ? DEFAULT_FLOWER_EMOJI : prev.emoji,
+                            isStandardFlower: false,
+                          }))
+                        }
+                      }}
+                      className="pr-8"
+                      autoComplete="off"
+                    />
+                    <ChevronDown className="absolute right-2 top-1/2 transform -translate-y-1/2 h-4 w-4 text-gray-400 pointer-events-none" />
+                    {/* Show suggestions only when typing and there's input */}
+                    {newFlower.name && newFlower.name.length > 0 && (
+                      <div className="absolute z-10 w-full mt-1 bg-white border border-gray-300 rounded-md shadow-lg max-h-60 overflow-auto">
+                        {STANDARD_FLOWERS
+                          .filter(flower => 
+                            flower.name.toLowerCase().includes(newFlower.name.toLowerCase())
+                          )
+                          .slice(0, 5)
+                          .map((flower) => (
+                            <div
+                              key={flower.name}
+                              className="px-3 py-2 cursor-pointer hover:bg-gray-100 flex items-center gap-2"
+                              onClick={() => {
+                                setNewFlower(prev => ({
+                                  ...prev,
+                                  name: flower.name,
+                                  emoji: flower.emoji,
+                                  color: flower.color,
+                                  isStandardFlower: true,
+                                }))
+                              }}
+                            >
+                              <span>{flower.emoji}</span>
+                              <span>{flower.name}</span>
+                            </div>
+                          ))}
+                      </div>
+                    )}
+                  </div>
+                  <p className="text-xs text-gray-500">
+                    Tip: Begin te typen om uit standaard bloemen te kiezen, of typ een eigen naam
+                  </p>
                 </div>
 
                 <div className="grid gap-2">
@@ -1872,16 +1931,75 @@ export default function PlantBedViewPage() {
                   <label htmlFor="edit-name" className="text-sm font-medium">
                     Bloemnaam *
                   </label>
-                  <FlowerSelector
-                    value={newFlower.name}
-                    onValueChange={(value) => {
-                      setNewFlower(prev => ({
-                        ...prev,
-                        name: value,
-                      }))
-                    }}
-                    placeholder="Zoek een bloem of typ een nieuwe naam..."
-                  />
+                  <div className="relative">
+                    <Input
+                      id="edit-name"
+                      placeholder="Typ een nieuwe bloem of kies uit de lijst..."
+                      value={newFlower.name}
+                      onChange={(e) => {
+                        const value = e.target.value
+                        setNewFlower(prev => ({
+                          ...prev,
+                          name: value,
+                        }))
+                        
+                        // Check if it matches a standard flower
+                        const selectedFlower = STANDARD_FLOWERS.find(f => 
+                          f.name.toLowerCase() === value.toLowerCase()
+                        )
+                        if (selectedFlower) {
+                          setNewFlower(prev => ({
+                            ...prev,
+                            name: value,
+                            emoji: selectedFlower.emoji,
+                            color: selectedFlower.color,
+                            isStandardFlower: true,
+                          }))
+                        } else {
+                          setNewFlower(prev => ({
+                            ...prev,
+                            name: value,
+                            emoji: prev.emoji === DEFAULT_FLOWER_EMOJI ? DEFAULT_FLOWER_EMOJI : prev.emoji,
+                            isStandardFlower: false,
+                          }))
+                        }
+                      }}
+                      className="pr-8"
+                      autoComplete="off"
+                    />
+                    <ChevronDown className="absolute right-2 top-1/2 transform -translate-y-1/2 h-4 w-4 text-gray-400 pointer-events-none" />
+                    {/* Show suggestions only when typing and there's input */}
+                    {newFlower.name && newFlower.name.length > 0 && (
+                      <div className="absolute z-10 w-full mt-1 bg-white border border-gray-300 rounded-md shadow-lg max-h-60 overflow-auto">
+                        {STANDARD_FLOWERS
+                          .filter(flower => 
+                            flower.name.toLowerCase().includes(newFlower.name.toLowerCase())
+                          )
+                          .slice(0, 5)
+                          .map((flower) => (
+                            <div
+                              key={flower.name}
+                              className="px-3 py-2 cursor-pointer hover:bg-gray-100 flex items-center gap-2"
+                              onClick={() => {
+                                setNewFlower(prev => ({
+                                  ...prev,
+                                  name: flower.name,
+                                  emoji: flower.emoji,
+                                  color: flower.color,
+                                  isStandardFlower: true,
+                                }))
+                              }}
+                            >
+                              <span>{flower.emoji}</span>
+                              <span>{flower.name}</span>
+                            </div>
+                          ))}
+                      </div>
+                    )}
+                  </div>
+                  <p className="text-xs text-gray-500">
+                    Tip: Begin te typen om uit standaard bloemen te kiezen, of typ een eigen naam
+                  </p>
                 </div>
 
                 {!newFlower.isStandardFlower && (

--- a/app/gardens/[id]/plantvak-view/[bedId]/page.tsx
+++ b/app/gardens/[id]/plantvak-view/[bedId]/page.tsx
@@ -8,6 +8,7 @@ import { Badge } from "@/components/ui/badge"
 import { Input } from "@/components/ui/input"
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { FlowerSelector } from "@/components/ui/flower-selector"
 import { Textarea } from "@/components/ui/textarea"
 import {
   Grid3X3,
@@ -1679,88 +1680,16 @@ export default function PlantBedViewPage() {
                   <label htmlFor="name" className="text-sm font-medium">
                     Bloemnaam *
                   </label>
-                  <div className="relative">
-                    <Input
-                      id="name"
-                      placeholder="Typ een nieuwe bloem of kies uit de lijst..."
-                      value={newFlower.name}
-                      onChange={(e) => {
-                        const value = e.target.value
-                        setNewFlower(prev => ({
-                          ...prev,
-                          name: value,
-                        }))
-                        
-                        // Check if it matches a standard flower
-                        const selectedFlower = STANDARD_FLOWERS.find(f => 
-                          f.name.toLowerCase() === value.toLowerCase()
-                        )
-                        if (selectedFlower) {
-                          setNewFlower(prev => ({
-                            ...prev,
-                            name: value,
-                            emoji: selectedFlower.emoji,
-                            plantColor: selectedFlower.color || '',
-                            type: value,
-                            isStandardFlower: true,
-                          }))
-                          setIsCustomFlower(false)
-                        } else {
-                          setNewFlower(prev => ({
-                            ...prev,
-                            name: value,
-                            emoji: prev.emoji === DEFAULT_FLOWER_EMOJI ? DEFAULT_FLOWER_EMOJI : prev.emoji,
-                            type: '',
-                            isStandardFlower: false,
-                          }))
-                          setIsCustomFlower(true)
-                        }
-                      }}
-                      className="pr-8"
-                      autoComplete="off"
-                    />
-                    <ChevronDown className="absolute right-2 top-1/2 transform -translate-y-1/2 h-4 w-4 text-gray-400 pointer-events-none" />
-                    {/* Show suggestions only when typing and there's input */}
-                    {newFlower.name && newFlower.name.length > 0 && (
-                      <div className="absolute z-[9999] w-full mt-1 bg-white border border-gray-300 rounded-md shadow-xl max-h-60 overflow-auto">
-                        {STANDARD_FLOWERS
-                          .filter(flower => 
-                            flower.name.toLowerCase().includes(newFlower.name.toLowerCase())
-                          )
-                          .slice(0, 8)
-                          .map((flower) => (
-                            <div
-                              key={flower.name}
-                              className="px-3 py-2 cursor-pointer hover:bg-green-50 hover:text-green-800 flex items-center gap-2 transition-colors"
-                              onClick={() => {
-                                setNewFlower(prev => ({
-                                  ...prev,
-                                  name: flower.name,
-                                  emoji: flower.emoji,
-                                  plantColor: flower.color || '',
-                                  type: flower.name,
-                                  isStandardFlower: true,
-                                }))
-                                setIsCustomFlower(false)
-                              }}
-                            >
-                              <span className="text-lg">{flower.emoji}</span>
-                              <span className="font-medium">{flower.name}</span>
-                            </div>
-                          ))}
-                        {STANDARD_FLOWERS.filter(flower => 
-                          flower.name.toLowerCase().includes(newFlower.name.toLowerCase())
-                        ).length === 0 && (
-                          <div className="px-3 py-2 text-gray-500 text-sm italic">
-                            Geen eenjarige bloemen gevonden. Typ een eigen naam.
-                          </div>
-                        )}
-                      </div>
-                    )}
-                  </div>
-                  <p className="text-xs text-gray-500">
-                    Tip: Begin te typen om uit standaard bloemen te kiezen, of typ een eigen naam
-                  </p>
+                  <FlowerSelector
+                    value={newFlower.name}
+                    onValueChange={(value) => {
+                      setNewFlower(prev => ({
+                        ...prev,
+                        name: value,
+                      }))
+                    }}
+                    placeholder="Zoek een bloem of typ een nieuwe naam..."
+                  />
                 </div>
 
                 <div className="grid gap-2">
@@ -1943,78 +1872,16 @@ export default function PlantBedViewPage() {
                   <label htmlFor="edit-name" className="text-sm font-medium">
                     Bloemnaam *
                   </label>
-                  <div className="relative">
-                    <Input
-                      id="edit-name"
-                      placeholder="Typ een nieuwe bloem of kies uit de lijst..."
-                      value={newFlower.name}
-                      onChange={(e) => {
-                        const value = e.target.value
-                        setNewFlower(prev => ({
-                          ...prev,
-                          name: value,
-                        }))
-                        
-                        // Check if it matches a standard flower
-                        const selectedFlower = STANDARD_FLOWERS.find(f => 
-                          f.name.toLowerCase() === value.toLowerCase()
-                        )
-                        if (selectedFlower) {
-                          setNewFlower(prev => ({
-                            ...prev,
-                            name: value,
-                            emoji: selectedFlower.emoji,
-                            plantColor: selectedFlower.color || '',
-                            type: value,
-                            isStandardFlower: true,
-                          }))
-                        } else {
-                          setNewFlower(prev => ({
-                            ...prev,
-                            name: value,
-                            emoji: prev.emoji === DEFAULT_FLOWER_EMOJI ? DEFAULT_FLOWER_EMOJI : prev.emoji,
-                            type: '',
-                            isStandardFlower: false,
-                          }))
-                        }
-                      }}
-                      className="pr-8"
-                      autoComplete="off"
-                    />
-                    <ChevronDown className="absolute right-2 top-1/2 transform -translate-y-1/2 h-4 w-4 text-gray-400 pointer-events-none" />
-                    {/* Show suggestions only when typing and there's input */}
-                    {newFlower.name && newFlower.name.length > 0 && (
-                      <div className="absolute z-50 w-full mt-1 bg-white border border-gray-300 rounded-md shadow-lg max-h-60 overflow-auto">
-                        {STANDARD_FLOWERS
-                          .filter(flower => 
-                            flower.name.toLowerCase().includes(newFlower.name.toLowerCase())
-                          )
-                          .slice(0, 5)
-                          .map((flower) => (
-                            <div
-                              key={flower.name}
-                              className="px-3 py-2 cursor-pointer hover:bg-gray-100 flex items-center gap-2"
-                              onClick={() => {
-                                setNewFlower(prev => ({
-                                  ...prev,
-                                  name: flower.name,
-                                  emoji: flower.emoji,
-                                  plantColor: flower.color || '',
-                                  type: flower.name,
-                                  isStandardFlower: true,
-                                }))
-                              }}
-                            >
-                              <span>{flower.emoji}</span>
-                              <span>{flower.name}</span>
-                            </div>
-                          ))}
-                      </div>
-                    )}
-                  </div>
-                  <p className="text-xs text-gray-500">
-                    Tip: Begin te typen om uit standaard bloemen te kiezen, of typ een eigen naam
-                  </p>
+                  <FlowerSelector
+                    value={newFlower.name}
+                    onValueChange={(value) => {
+                      setNewFlower(prev => ({
+                        ...prev,
+                        name: value,
+                      }))
+                    }}
+                    placeholder="Zoek een bloem of typ een nieuwe naam..."
+                  />
                 </div>
 
                 {!newFlower.isStandardFlower && (

--- a/app/logbook/[id]/edit/page.tsx
+++ b/app/logbook/[id]/edit/page.tsx
@@ -163,7 +163,7 @@ export default function EditLogbookPage() {
         throw new Error(result.error || 'Failed to upload photo')
       }
 
-      setFormData(prev => ({ ...prev, photo_url: result.url }))
+      setFormData(prev => ({ ...prev, photo_url: result.url as string }))
 
       toast({
         title: "Foto geüpload",

--- a/app/logbook/[id]/edit/page.tsx
+++ b/app/logbook/[id]/edit/page.tsx
@@ -121,10 +121,10 @@ export default function EditLogbookPage() {
     try {
       const updateData = {
         plant_bed_id: formData.plant_bed_id,
-        plant_id: formData.plant_id,
+        plant_id: formData.plant_id || undefined,
         entry_date: formData.entry_date,
         notes: formData.notes.trim(),
-        photo_url: formData.photo_url,
+        photo_url: formData.photo_url || undefined,
       }
 
       const response = await LogbookService.update(state.entry.id, updateData)

--- a/app/logbook/[id]/edit/page.tsx
+++ b/app/logbook/[id]/edit/page.tsx
@@ -1,0 +1,423 @@
+"use client"
+
+import * as React from "react"
+import { useRouter, useParams } from "next/navigation"
+import Link from "next/link"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Textarea } from "@/components/ui/textarea"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { useToast } from "@/hooks/use-toast"
+import { ArrowLeft, Calendar, Save, Upload, X, Image as ImageIcon } from "lucide-react"
+import { LogbookService } from "@/lib/services/database.service"
+import { getPlantBeds } from "@/lib/database"
+import { uploadImage, type UploadResult } from "@/lib/storage"
+import type { LogbookEntryWithDetails, PlantvakWithBloemen } from "@/lib/types/index"
+import { format } from "date-fns"
+
+interface EditLogbookState {
+  entry: LogbookEntryWithDetails | null
+  plantBeds: PlantvakWithBloemen[]
+  loading: boolean
+  saving: boolean
+  error: string | null
+  uploadingPhoto: boolean
+}
+
+interface EditFormData {
+  plant_bed_id: string
+  plant_id: string | null
+  entry_date: string
+  notes: string
+  photo_url: string | null
+}
+
+export default function EditLogbookPage() {
+  const router = useRouter()
+  const params = useParams()
+  const { toast } = useToast()
+  
+  const [state, setState] = React.useState<EditLogbookState>({
+    entry: null,
+    plantBeds: [],
+    loading: true,
+    saving: false,
+    error: null,
+    uploadingPhoto: false,
+  })
+
+  const [formData, setFormData] = React.useState<EditFormData>({
+    plant_bed_id: '',
+    plant_id: null,
+    entry_date: '',
+    notes: '',
+    photo_url: null,
+  })
+
+  const fileInputRef = React.useRef<HTMLInputElement>(null)
+
+  // Load logbook entry and plant beds
+  React.useEffect(() => {
+    const loadData = async () => {
+      try {
+        setState(prev => ({ ...prev, loading: true, error: null }))
+
+        // Load logbook entry
+        const entryResponse = await LogbookService.getById(params.id as string)
+        if (!entryResponse.success || !entryResponse.data) {
+          throw new Error(entryResponse.error || 'Failed to load logbook entry')
+        }
+
+        const entry = entryResponse.data
+        
+        // Load plant beds
+        const plantBeds = await getPlantBeds(entry.garden_id)
+
+        // Set form data
+        setFormData({
+          plant_bed_id: entry.plant_bed_id,
+          plant_id: entry.plant_id,
+          entry_date: entry.entry_date,
+          notes: entry.notes,
+          photo_url: entry.photo_url,
+        })
+
+        setState(prev => ({
+          ...prev,
+          entry,
+          plantBeds: plantBeds as PlantvakWithBloemen[],
+          loading: false,
+        }))
+
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : 'Failed to load data'
+        setState(prev => ({
+          ...prev,
+          loading: false,
+          error: errorMessage,
+        }))
+      }
+    }
+
+    loadData()
+  }, [params.id])
+
+  // Get plants for selected plant bed
+  const availablePlants = React.useMemo(() => {
+    const selectedBed = state.plantBeds.find(bed => bed.id === formData.plant_bed_id)
+    return selectedBed?.plants || []
+  }, [state.plantBeds, formData.plant_bed_id])
+
+  // Handle form submission
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    
+    if (!state.entry) return
+
+    setState(prev => ({ ...prev, saving: true }))
+
+    try {
+      const updateData = {
+        plant_bed_id: formData.plant_bed_id,
+        plant_id: formData.plant_id,
+        entry_date: formData.entry_date,
+        notes: formData.notes.trim(),
+        photo_url: formData.photo_url,
+      }
+
+      const response = await LogbookService.update(state.entry.id, updateData)
+      
+      if (!response.success) {
+        throw new Error(response.error || 'Failed to update logbook entry')
+      }
+
+      toast({
+        title: "Logboek entry bijgewerkt",
+        description: "De entry is succesvol bijgewerkt.",
+      })
+
+      router.push(`/logbook/${state.entry.id}`)
+
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : 'Failed to update entry'
+      toast({
+        title: "Fout bij bijwerken",
+        description: errorMessage,
+        variant: "destructive",
+      })
+    } finally {
+      setState(prev => ({ ...prev, saving: false }))
+    }
+  }
+
+  // Handle photo upload
+  const handlePhotoUpload = async (file: File) => {
+    setState(prev => ({ ...prev, uploadingPhoto: true }))
+
+    try {
+      const result: UploadResult = await uploadImage(file, 'logbook')
+      
+      if (!result.success) {
+        throw new Error(result.error || 'Failed to upload photo')
+      }
+
+      setFormData(prev => ({ ...prev, photo_url: result.url }))
+
+      toast({
+        title: "Foto geüpload",
+        description: "De foto is succesvol geüpload.",
+      })
+
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : 'Failed to upload photo'
+      toast({
+        title: "Fout bij uploaden",
+        description: errorMessage,
+        variant: "destructive",
+      })
+    } finally {
+      setState(prev => ({ ...prev, uploadingPhoto: false }))
+    }
+  }
+
+  // Handle file input change
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    if (file) {
+      handlePhotoUpload(file)
+    }
+  }
+
+  // Remove photo
+  const removePhoto = () => {
+    setFormData(prev => ({ ...prev, photo_url: null }))
+    if (fileInputRef.current) {
+      fileInputRef.current.value = ''
+    }
+  }
+
+  if (state.loading) {
+    return (
+      <div className="container mx-auto px-4 py-8">
+        <div className="max-w-2xl mx-auto">
+          <div className="text-center">
+            <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-green-600 mx-auto mb-4"></div>
+            <p className="text-gray-600">Logboek entry laden...</p>
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  if (state.error || !state.entry) {
+    return (
+      <div className="container mx-auto px-4 py-8">
+        <div className="max-w-2xl mx-auto text-center">
+          <h2 className="text-2xl font-bold text-gray-900 mb-4">
+            Entry niet gevonden
+          </h2>
+          <p className="text-gray-600 mb-6">
+            {state.error || 'De opgevraagde logboek entry bestaat niet of is verwijderd.'}
+          </p>
+          <Button asChild>
+            <Link href="/logbook">
+              <ArrowLeft className="h-4 w-4 mr-2" />
+              Terug naar logboek
+            </Link>
+          </Button>
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="container mx-auto px-4 py-8">
+      <div className="max-w-2xl mx-auto">
+        {/* Back button */}
+        <Button asChild variant="ghost" className="mb-6">
+          <Link href={`/logbook/${state.entry.id}`}>
+            <ArrowLeft className="h-4 w-4 mr-2" />
+            Terug naar entry
+          </Link>
+        </Button>
+
+        {/* Header */}
+        <div className="mb-8">
+          <h1 className="text-3xl font-bold text-gray-900 mb-2">
+            Logboek Entry Bewerken
+          </h1>
+          <p className="text-gray-600">
+            Bewerk de details van deze logboek entry
+          </p>
+        </div>
+
+        {/* Form */}
+        <Card>
+          <CardHeader>
+            <CardTitle>Entry Details</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <form onSubmit={handleSubmit} className="space-y-6">
+              {/* Plant bed selection */}
+              <div className="space-y-2">
+                <Label htmlFor="plant_bed">Plantvak *</Label>
+                <Select 
+                  value={formData.plant_bed_id} 
+                  onValueChange={(value) => {
+                    setFormData(prev => ({ 
+                      ...prev, 
+                      plant_bed_id: value,
+                      plant_id: null // Reset plant selection when bed changes
+                    }))
+                  }}
+                >
+                  <SelectTrigger>
+                    <SelectValue placeholder="Selecteer een plantvak" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {state.plantBeds.map((bed) => (
+                      <SelectItem key={bed.id} value={bed.id}>
+                        {bed.name}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+
+              {/* Plant selection */}
+              <div className="space-y-2">
+                <Label htmlFor="plant">Plant (optioneel)</Label>
+                <Select 
+                  value={formData.plant_id || ''} 
+                  onValueChange={(value) => {
+                    setFormData(prev => ({ 
+                      ...prev, 
+                      plant_id: value || null
+                    }))
+                  }}
+                >
+                  <SelectTrigger>
+                    <SelectValue placeholder="Selecteer een plant (optioneel)" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="">Geen specifieke plant</SelectItem>
+                    {availablePlants.map((plant) => (
+                      <SelectItem key={plant.id} value={plant.id}>
+                        {plant.name}
+                        {plant.variety && ` (${plant.variety})`}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+
+              {/* Entry date */}
+              <div className="space-y-2">
+                <Label htmlFor="entry_date">Datum *</Label>
+                <Input
+                  id="entry_date"
+                  type="date"
+                  value={formData.entry_date}
+                  onChange={(e) => setFormData(prev => ({ ...prev, entry_date: e.target.value }))}
+                  required
+                />
+              </div>
+
+              {/* Photo */}
+              <div className="space-y-2">
+                <Label>Foto (optioneel)</Label>
+                <div className="space-y-3">
+                  {formData.photo_url ? (
+                    <div className="relative">
+                      <img 
+                        src={formData.photo_url} 
+                        alt="Logboek foto"
+                        className="w-full max-h-64 object-cover rounded-lg border"
+                      />
+                      <Button
+                        type="button"
+                        variant="destructive"
+                        size="sm"
+                        className="absolute top-2 right-2"
+                        onClick={removePhoto}
+                      >
+                        <X className="h-4 w-4" />
+                      </Button>
+                    </div>
+                  ) : (
+                    <div className="border-2 border-dashed border-gray-300 rounded-lg p-6 text-center">
+                      <ImageIcon className="h-8 w-8 text-gray-400 mx-auto mb-2" />
+                      <p className="text-sm text-gray-600 mb-2">Geen foto geselecteerd</p>
+                    </div>
+                  )}
+                  
+                  <div className="flex gap-2">
+                    <Button
+                      type="button"
+                      variant="outline"
+                      onClick={() => fileInputRef.current?.click()}
+                      disabled={state.uploadingPhoto}
+                    >
+                      <Upload className="h-4 w-4 mr-2" />
+                      {state.uploadingPhoto ? 'Uploaden...' : formData.photo_url ? 'Foto vervangen' : 'Foto uploaden'}
+                    </Button>
+                    {formData.photo_url && (
+                      <Button
+                        type="button"
+                        variant="outline"
+                        onClick={removePhoto}
+                      >
+                        <X className="h-4 w-4 mr-2" />
+                        Verwijderen
+                      </Button>
+                    )}
+                  </div>
+                  
+                  <input
+                    ref={fileInputRef}
+                    type="file"
+                    accept="image/*"
+                    onChange={handleFileChange}
+                    className="hidden"
+                  />
+                </div>
+              </div>
+
+              {/* Notes */}
+              <div className="space-y-2">
+                <Label htmlFor="notes">Opmerkingen *</Label>
+                <Textarea
+                  id="notes"
+                  value={formData.notes}
+                  onChange={(e) => setFormData(prev => ({ ...prev, notes: e.target.value }))}
+                  placeholder="Beschrijf wat je hebt gedaan, waargenomen of wat er aandacht behoeft..."
+                  rows={6}
+                  required
+                />
+              </div>
+
+              {/* Submit buttons */}
+              <div className="flex gap-3 pt-6">
+                <Button 
+                  type="submit" 
+                  disabled={state.saving || !formData.notes.trim()}
+                  className="flex-1"
+                >
+                  <Save className="h-4 w-4 mr-2" />
+                  {state.saving ? 'Opslaan...' : 'Wijzigingen opslaan'}
+                </Button>
+                <Button asChild variant="outline">
+                  <Link href={`/logbook/${state.entry.id}`}>
+                    Annuleren
+                  </Link>
+                </Button>
+              </div>
+            </form>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  )
+}

--- a/app/logbook/[id]/edit/page.tsx
+++ b/app/logbook/[id]/edit/page.tsx
@@ -78,10 +78,10 @@ export default function EditLogbookPage() {
         // Set form data
         setFormData({
           plant_bed_id: entry.plant_bed_id,
-          plant_id: entry.plant_id,
+          plant_id: entry.plant_id || null,
           entry_date: entry.entry_date,
           notes: entry.notes,
-          photo_url: entry.photo_url,
+          photo_url: entry.photo_url || null,
         })
 
         setState(prev => ({

--- a/app/logbook/page.tsx
+++ b/app/logbook/page.tsx
@@ -438,8 +438,16 @@ function LogbookPageContent() {
                     </p>
                   </TableCell>
                   <TableCell className="text-center">
-                    {entry.photo_url && (
-                      <Camera className="h-4 w-4 text-gray-400 mx-auto" />
+                    {entry.photo_url ? (
+                      <div className="flex justify-center">
+                        <img 
+                          src={entry.photo_url} 
+                          alt="Logboek foto"
+                          className="w-12 h-12 object-cover rounded-lg border border-gray-200"
+                        />
+                      </div>
+                    ) : (
+                      <span className="text-gray-400 text-xs">Geen foto</span>
                     )}
                   </TableCell>
                 </TableRow>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -250,12 +250,7 @@ function HomePageContent() {
             <Grid3X3 className="h-4 w-4 mr-1" />
             {isVisualView ? "Lijst" : "Visueel"}
           </Button>
-          <Button asChild variant="outline" className="border-green-600 text-green-600 hover:bg-green-50">
-            <Link href="/tasks">
-              <Calendar className="h-4 w-4 mr-2" />
-              Taken
-            </Link>
-          </Button>
+
           <Button asChild className="bg-green-600 hover:bg-green-700">
             <Link href="/gardens/new">
               <Plus className="h-4 w-4 mr-2" />

--- a/components/navigation.tsx
+++ b/components/navigation.tsx
@@ -31,17 +31,22 @@ export function Navigation() {
     <nav className="bg-white border-b border-gray-200 sticky top-0 z-50">
       <div className="container mx-auto px-4">
         <div className="flex items-center justify-between h-16">
-          {/* Logo */}
-          <Link href="/" className="flex items-center gap-2 font-semibold text-gray-900">
-            <div className="p-2 bg-green-100 rounded-lg">
-              <TreePine className="h-5 w-5 text-green-600" />
+          {/* Home Button */}
+          <Link href="/" className={cn(
+            "flex items-center gap-2 px-3 py-2 rounded-md text-sm font-medium transition-colors",
+            pathname === "/"
+              ? "bg-green-100 text-green-700"
+              : "text-gray-600 hover:text-gray-900 hover:bg-gray-100"
+          )}>
+            <div className="p-1 bg-green-100 rounded-lg">
+              <TreePine className="h-4 w-4 text-green-600" />
             </div>
-            <span className="hidden sm:block">Tuinbeheer</span>
+            <span>Home</span>
           </Link>
 
           {/* Navigation items */}
           <div className="flex items-center space-x-1">
-            {navigationItems.map((item) => {
+            {navigationItems.filter(item => item.href !== "/").map((item) => {
               const isActive = pathname === item.href || 
                 (item.href !== "/" && pathname.startsWith(item.href))
               

--- a/components/navigation.tsx
+++ b/components/navigation.tsx
@@ -8,7 +8,7 @@ import { TreePine, BookOpen, Home, Settings } from "lucide-react"
 
 const navigationItems = [
   {
-    name: "Dashboard",
+    name: "Home",
     href: "/",
     icon: Home,
   },

--- a/components/tasks/task-details-dialog.tsx
+++ b/components/tasks/task-details-dialog.tsx
@@ -191,7 +191,7 @@ export function TaskDetailsDialog({
               <Badge variant={task.completed ? "default" : "secondary"}>
                 {task.completed ? "Voltooid" : "Actief"}
               </Badge>
-              <Badge variant="outline" className={priorityConfig?.className}>
+              <Badge variant="outline" className={priorityConfig?.badge_color}>
                 {priorityConfig?.label}
               </Badge>
                               <Badge variant="outline">

--- a/components/tasks/task-details-dialog.tsx
+++ b/components/tasks/task-details-dialog.tsx
@@ -1,0 +1,411 @@
+"use client"
+
+import React, { useState, useEffect } from 'react'
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Textarea } from "@/components/ui/textarea"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { Badge } from "@/components/ui/badge"
+import { Label } from "@/components/ui/label"
+import { Calendar, Edit2, Save, X, Trash2 } from "lucide-react"
+import { TaskService } from "@/lib/services/task.service"
+import { useToast } from "@/hooks/use-toast"
+import type { WeeklyTask, UpdateTaskData } from "@/lib/types/tasks"
+import { getTaskTypeConfig, getPriorityConfig } from "@/lib/types/tasks"
+
+interface TaskDetailsDialogProps {
+  task: WeeklyTask | null
+  isOpen: boolean
+  onClose: () => void
+  onTaskUpdated?: () => void
+  onTaskDeleted?: () => void
+}
+
+export function TaskDetailsDialog({ 
+  task, 
+  isOpen, 
+  onClose, 
+  onTaskUpdated, 
+  onTaskDeleted 
+}: TaskDetailsDialogProps) {
+  const { toast } = useToast()
+  const [isEditing, setIsEditing] = useState(false)
+  const [isLoading, setIsLoading] = useState(false)
+  const [formData, setFormData] = useState({
+    title: '',
+    description: '',
+    due_date: '',
+    priority: 'medium' as 'low' | 'medium' | 'high',
+    task_type: 'general' as 'watering' | 'fertilizing' | 'pruning' | 'harvesting' | 'planting' | 'pest_control' | 'general',
+    notes: ''
+  })
+
+  // Update form data when task changes
+  useEffect(() => {
+    if (task) {
+      setFormData({
+        title: task.title,
+        description: task.description || '',
+        due_date: task.due_date.split('T')[0], // Convert to date format
+        priority: task.priority,
+        task_type: task.task_type,
+        notes: task.notes || ''
+      })
+    }
+  }, [task])
+
+  // Reset editing state when dialog opens/closes
+  useEffect(() => {
+    if (!isOpen) {
+      setIsEditing(false)
+    }
+  }, [isOpen])
+
+  const handleSave = async () => {
+    if (!task) return
+
+    setIsLoading(true)
+    try {
+      const updateData: UpdateTaskData = {
+        title: formData.title.trim(),
+        description: formData.description.trim() || undefined,
+        due_date: formData.due_date,
+        priority: formData.priority,
+        task_type: formData.task_type,
+        notes: formData.notes.trim() || undefined
+      }
+
+      const { error } = await TaskService.updateTask(task.id, updateData)
+      
+      if (error) {
+        throw new Error(error)
+      }
+
+      toast({
+        title: "Taak bijgewerkt",
+        description: "De taak is succesvol bijgewerkt.",
+      })
+
+      setIsEditing(false)
+      onTaskUpdated?.()
+    } catch (error) {
+      console.error('Error updating task:', error)
+      toast({
+        title: "Fout bij bijwerken",
+        description: error instanceof Error ? error.message : "Er ging iets mis bij het bijwerken van de taak.",
+        variant: "destructive",
+      })
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  const handleDelete = async () => {
+    if (!task) return
+
+    if (!confirm(`Weet u zeker dat u de taak "${task.title}" wilt verwijderen?`)) {
+      return
+    }
+
+    setIsLoading(true)
+    try {
+      const { error } = await TaskService.deleteTask(task.id)
+      
+      if (error) {
+        throw new Error(error)
+      }
+
+      toast({
+        title: "Taak verwijderd",
+        description: "De taak is succesvol verwijderd.",
+      })
+
+      onTaskDeleted?.()
+      onClose()
+    } catch (error) {
+      console.error('Error deleting task:', error)
+      toast({
+        title: "Fout bij verwijderen",
+        description: error instanceof Error ? error.message : "Er ging iets mis bij het verwijderen van de taak.",
+        variant: "destructive",
+      })
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  const handleToggleComplete = async () => {
+    if (!task) return
+
+    setIsLoading(true)
+    try {
+      const { error } = await TaskService.updateTask(task.id, { completed: !task.completed })
+      
+      if (error) {
+        throw new Error(error)
+      }
+
+      toast({
+        title: task.completed ? "Taak gemarkeerd als niet voltooid" : "Taak voltooid",
+        description: task.completed 
+          ? "De taak is gemarkeerd als niet voltooid." 
+          : "De taak is voltooid en toegevoegd aan het logboek.",
+      })
+
+      onTaskUpdated?.()
+    } catch (error) {
+      console.error('Error toggling task completion:', error)
+      toast({
+        title: "Fout",
+        description: error instanceof Error ? error.message : "Er ging iets mis.",
+        variant: "destructive",
+      })
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  if (!task) return null
+
+  const taskTypeConfig = getTaskTypeConfig(task.task_type)
+  const priorityConfig = getPriorityConfig(task.priority)
+
+  return (
+    <Dialog open={isOpen} onOpenChange={onClose}>
+      <DialogContent className="max-w-2xl">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Calendar className="h-5 w-5 text-green-600" />
+            Taak Details
+          </DialogTitle>
+          <DialogDescription>
+            Bekijk en bewerk de details van deze taak
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-6">
+          {/* Task Status and Actions */}
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              <Badge variant={task.completed ? "default" : "secondary"}>
+                {task.completed ? "Voltooid" : "Actief"}
+              </Badge>
+              <Badge variant="outline" className={priorityConfig.className}>
+                {priorityConfig.label}
+              </Badge>
+              <Badge variant="outline">
+                {taskTypeConfig.label}
+              </Badge>
+            </div>
+            <div className="flex items-center gap-2">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={handleToggleComplete}
+                disabled={isLoading}
+              >
+                {task.completed ? "Markeer als niet voltooid" : "Markeer als voltooid"}
+              </Button>
+              {!isEditing ? (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setIsEditing(true)}
+                  disabled={isLoading}
+                >
+                  <Edit2 className="h-4 w-4 mr-1" />
+                  Bewerken
+                </Button>
+              ) : (
+                <div className="flex gap-1">
+                  <Button
+                    size="sm"
+                    onClick={handleSave}
+                    disabled={isLoading}
+                  >
+                    <Save className="h-4 w-4 mr-1" />
+                    Opslaan
+                  </Button>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => setIsEditing(false)}
+                    disabled={isLoading}
+                  >
+                    <X className="h-4 w-4" />
+                  </Button>
+                </div>
+              )}
+              <Button
+                variant="destructive"
+                size="sm"
+                onClick={handleDelete}
+                disabled={isLoading}
+              >
+                <Trash2 className="h-4 w-4" />
+              </Button>
+            </div>
+          </div>
+
+          {/* Plant Information */}
+          <div className="bg-green-50 rounded-lg p-4">
+            <h3 className="font-medium text-green-800 mb-2">Plant Informatie</h3>
+            <div className="grid grid-cols-2 gap-4 text-sm">
+              <div>
+                <span className="text-green-600 font-medium">Plant:</span>
+                <p className="text-green-800">{task.plant_name}</p>
+              </div>
+              <div>
+                <span className="text-green-600 font-medium">Plantvak:</span>
+                <p className="text-green-800">{task.plant_bed_name}</p>
+              </div>
+              <div>
+                <span className="text-green-600 font-medium">Tuin:</span>
+                <p className="text-green-800">{task.garden_name}</p>
+              </div>
+              <div>
+                <span className="text-green-600 font-medium">Vervaldatum:</span>
+                <p className="text-green-800">
+                  {new Date(task.due_date).toLocaleDateString('nl-NL', {
+                    weekday: 'long',
+                    year: 'numeric',
+                    month: 'long',
+                    day: 'numeric'
+                  })}
+                </p>
+              </div>
+            </div>
+          </div>
+
+          {/* Task Details Form */}
+          <div className="space-y-4">
+            <div>
+              <Label htmlFor="title">Titel</Label>
+              {isEditing ? (
+                <Input
+                  id="title"
+                  value={formData.title}
+                  onChange={(e) => setFormData(prev => ({ ...prev, title: e.target.value }))}
+                  disabled={isLoading}
+                />
+              ) : (
+                <p className="text-lg font-medium mt-1">{task.title}</p>
+              )}
+            </div>
+
+            <div>
+              <Label htmlFor="description">Beschrijving</Label>
+              {isEditing ? (
+                <Textarea
+                  id="description"
+                  value={formData.description}
+                  onChange={(e) => setFormData(prev => ({ ...prev, description: e.target.value }))}
+                  disabled={isLoading}
+                  rows={3}
+                />
+              ) : (
+                <p className="mt-1 text-gray-700">{task.description || "Geen beschrijving"}</p>
+              )}
+            </div>
+
+            {isEditing && (
+              <>
+                <div className="grid grid-cols-2 gap-4">
+                  <div>
+                    <Label htmlFor="due_date">Vervaldatum</Label>
+                    <Input
+                      id="due_date"
+                      type="date"
+                      value={formData.due_date}
+                      onChange={(e) => setFormData(prev => ({ ...prev, due_date: e.target.value }))}
+                      disabled={isLoading}
+                    />
+                  </div>
+                  <div>
+                    <Label htmlFor="priority">Prioriteit</Label>
+                    <Select 
+                      value={formData.priority} 
+                      onValueChange={(value: 'low' | 'medium' | 'high') => 
+                        setFormData(prev => ({ ...prev, priority: value }))
+                      }
+                      disabled={isLoading}
+                    >
+                      <SelectTrigger>
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="low">Laag</SelectItem>
+                        <SelectItem value="medium">Gemiddeld</SelectItem>
+                        <SelectItem value="high">Hoog</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </div>
+                </div>
+
+                <div>
+                  <Label htmlFor="task_type">Type Taak</Label>
+                  <Select 
+                    value={formData.task_type} 
+                    onValueChange={(value: any) => 
+                      setFormData(prev => ({ ...prev, task_type: value }))
+                    }
+                    disabled={isLoading}
+                  >
+                    <SelectTrigger>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="watering">Water geven</SelectItem>
+                      <SelectItem value="fertilizing">Bemesten</SelectItem>
+                      <SelectItem value="pruning">Snoeien</SelectItem>
+                      <SelectItem value="harvesting">Oogsten</SelectItem>
+                      <SelectItem value="planting">Planten</SelectItem>
+                      <SelectItem value="pest_control">Plaagbestrijding</SelectItem>
+                      <SelectItem value="general">Algemeen</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+              </>
+            )}
+
+            <div>
+              <Label htmlFor="notes">Opmerkingen</Label>
+              {isEditing ? (
+                <Textarea
+                  id="notes"
+                  value={formData.notes}
+                  onChange={(e) => setFormData(prev => ({ ...prev, notes: e.target.value }))}
+                  disabled={isLoading}
+                  rows={3}
+                />
+              ) : (
+                <p className="mt-1 text-gray-700">{task.notes || "Geen opmerkingen"}</p>
+              )}
+            </div>
+          </div>
+
+          {/* Timestamps */}
+          <div className="text-sm text-gray-500 border-t pt-4">
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <span className="font-medium">Aangemaakt:</span>
+                <p>{new Date(task.created_at).toLocaleString('nl-NL')}</p>
+              </div>
+              <div>
+                <span className="font-medium">Laatst bijgewerkt:</span>
+                <p>{new Date(task.updated_at).toLocaleString('nl-NL')}</p>
+              </div>
+              {task.completed_at && (
+                <div className="col-span-2">
+                  <span className="font-medium">Voltooid op:</span>
+                  <p>{new Date(task.completed_at).toLocaleString('nl-NL')}</p>
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/components/tasks/task-details-dialog.tsx
+++ b/components/tasks/task-details-dialog.tsx
@@ -191,12 +191,12 @@ export function TaskDetailsDialog({
               <Badge variant={task.completed ? "default" : "secondary"}>
                 {task.completed ? "Voltooid" : "Actief"}
               </Badge>
-              <Badge variant="outline" className={priorityConfig.className}>
-                {priorityConfig.label}
+              <Badge variant="outline" className={priorityConfig?.className}>
+                {priorityConfig?.label}
               </Badge>
-              <Badge variant="outline">
-                {taskTypeConfig.label}
-              </Badge>
+                              <Badge variant="outline">
+                  {taskTypeConfig?.label}
+                </Badge>
             </div>
             <div className="flex items-center gap-2">
               <Button

--- a/components/tasks/weekly-task-list.tsx
+++ b/components/tasks/weekly-task-list.tsx
@@ -4,7 +4,7 @@ import React, { useState, useEffect } from 'react'
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
-
+import { TaskDetailsDialog } from "./task-details-dialog"
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog"
 import { 
   Calendar, 
@@ -55,6 +55,10 @@ export function WeeklyTaskList({ onTaskEdit, onTaskAdd }: WeeklyTaskListProps) {
 
   // Add loading state for individual tasks
   const [updatingTasks, setUpdatingTasks] = useState<Set<string>>(new Set())
+  
+  // Task details dialog state
+  const [selectedTask, setSelectedTask] = useState<WeeklyTask | null>(null)
+  const [showTaskDialog, setShowTaskDialog] = useState(false)
 
   // Load weekly calendar
   const loadWeeklyCalendar = async (weekStart: Date) => {
@@ -138,8 +142,16 @@ export function WeeklyTaskList({ onTaskEdit, onTaskAdd }: WeeklyTaskListProps) {
     const taskTypeConfig = getTaskTypeConfig(task.task_type)
     const priorityConfig = getPriorityConfig(task.priority)
     
+    const handleTaskDoubleClick = () => {
+      setSelectedTask(task)
+      setShowTaskDialog(true)
+    }
+    
     return (
-      <Card className={`mb-3 transition-all duration-200 ${task.completed ? 'opacity-70 bg-gray-50 border-gray-300' : 'bg-white border-gray-200'} ${compact ? 'p-2' : ''}`}>
+      <Card 
+        className={`mb-3 transition-all duration-200 cursor-pointer hover:shadow-md ${task.completed ? 'opacity-70 bg-gray-50 border-gray-300' : 'bg-white border-gray-200'} ${compact ? 'p-2' : ''}`}
+        onDoubleClick={handleTaskDoubleClick}
+      >
         <CardContent className={compact ? 'p-3' : 'p-4'}>
           <div className="flex items-start gap-3">
             {/* Simple button approach instead of Checkbox for better reliability */}
@@ -555,6 +567,22 @@ export function WeeklyTaskList({ onTaskEdit, onTaskAdd }: WeeklyTaskListProps) {
           </CardContent>
         </Card>
       )}
+
+      {/* Task Details Dialog */}
+      <TaskDetailsDialog
+        task={selectedTask}
+        isOpen={showTaskDialog}
+        onClose={() => {
+          setShowTaskDialog(false)
+          setSelectedTask(null)
+        }}
+        onTaskUpdated={() => {
+          loadWeeklyCalendar(currentWeekStart)
+        }}
+        onTaskDeleted={() => {
+          loadWeeklyCalendar(currentWeekStart)
+        }}
+      />
     </div>
   )
 }

--- a/components/ui/plant-form.tsx
+++ b/components/ui/plant-form.tsx
@@ -1,0 +1,461 @@
+"use client"
+
+import * as React from "react"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Label } from "@/components/ui/label"
+import { Textarea } from "@/components/ui/textarea"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible"
+import { ChevronDown, ChevronUp, AlertCircle } from "lucide-react"
+
+// Standard flower types with emojis
+const STANDARD_FLOWERS = [
+  { name: 'Roos', emoji: '🌹', color: '#FF69B4' },
+  { name: 'Tulp', emoji: '🌷', color: '#FF4500' },
+  { name: 'Zonnebloem', emoji: '🌻', color: '#FFD700' },
+  { name: 'Lavendel', emoji: '🪻', color: '#9370DB' },
+  { name: 'Dahlia', emoji: '🌺', color: '#FF1493' },
+  { name: 'Chrysant', emoji: '🌼', color: '#FFA500' },
+  { name: 'Narcis', emoji: '🌻', color: '#FFFF00' },
+  { name: 'Iris', emoji: '🌸', color: '#4B0082' },
+  { name: 'Petunia', emoji: '🌺', color: '#FF6B6B' },
+  { name: 'Begonia', emoji: '🌸', color: '#FF8C69' },
+  { name: 'Lelie', emoji: '🌺', color: '#FF69B4' },
+  { name: 'Anjer', emoji: '🌸', color: '#FF1493' },
+]
+
+const DEFAULT_FLOWER_EMOJI = '🌼'
+
+export interface PlantFormData {
+  name: string
+  color: string
+  height: string
+  // Optional advanced fields
+  scientificName: string
+  latinName: string
+  variety: string
+  plantColor: string
+  plantHeight: string
+  plantsPerSqm: string
+  sunPreference: 'full-sun' | 'partial-sun' | 'shade'
+  plantingDate: string
+  expectedHarvestDate: string
+  status: "gezond" | "aandacht_nodig" | "ziek" | "dood" | "geoogst"
+  notes: string
+  careInstructions: string
+  wateringFrequency: string
+  fertilizerSchedule: string
+  emoji: string
+  isStandardFlower: boolean
+}
+
+export interface PlantFormErrors {
+  name?: string
+  color?: string
+  height?: string
+  [key: string]: string | undefined
+}
+
+interface PlantFormProps {
+  data: PlantFormData
+  errors: PlantFormErrors
+  onChange: (data: PlantFormData) => void
+  onSubmit: (e: React.FormEvent) => void
+  onReset?: () => void
+  submitLabel?: string
+  isSubmitting?: boolean
+  showAdvanced?: boolean
+}
+
+export function PlantForm({
+  data,
+  errors,
+  onChange,
+  onSubmit,
+  onReset,
+  submitLabel = "Plant toevoegen",
+  isSubmitting = false,
+  showAdvanced = true
+}: PlantFormProps) {
+  const [isAdvancedOpen, setIsAdvancedOpen] = React.useState(false)
+
+  const handleFieldChange = (field: keyof PlantFormData, value: string | boolean) => {
+    onChange({ ...data, [field]: value })
+  }
+
+  const handleNameChange = (value: string) => {
+    // Check if it matches a standard flower
+    const selectedFlower = STANDARD_FLOWERS.find(f => 
+      f.name.toLowerCase() === value.toLowerCase()
+    )
+    
+    if (selectedFlower) {
+      onChange({
+        ...data,
+        name: value,
+        emoji: selectedFlower.emoji,
+        color: data.color || selectedFlower.color,
+        isStandardFlower: true,
+      })
+    } else {
+      onChange({
+        ...data,
+        name: value,
+        emoji: data.emoji === DEFAULT_FLOWER_EMOJI ? DEFAULT_FLOWER_EMOJI : data.emoji,
+        isStandardFlower: false,
+      })
+    }
+  }
+
+  return (
+    <form onSubmit={onSubmit} onReset={onReset} className="space-y-6">
+      {/* Required Fields */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Basis Informatie</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {/* Plant Name with suggestions */}
+          <div className="space-y-2">
+            <Label htmlFor="name">Bloemnaam *</Label>
+            <div className="relative">
+              <Input
+                id="name"
+                placeholder="Typ een nieuwe bloem of kies uit de lijst..."
+                value={data.name}
+                onChange={(e) => handleNameChange(e.target.value)}
+                className={`${errors.name ? "border-destructive" : ""} pr-8`}
+                required
+                autoComplete="off"
+              />
+              <ChevronDown className="absolute right-2 top-1/2 transform -translate-y-1/2 h-4 w-4 text-gray-400 pointer-events-none" />
+              
+              {/* Suggestions dropdown */}
+              {data.name && data.name.length > 0 && (
+                <div className="absolute z-10 w-full mt-1 bg-white border border-gray-300 rounded-md shadow-lg max-h-60 overflow-auto">
+                  {STANDARD_FLOWERS
+                    .filter(flower => 
+                      flower.name.toLowerCase().includes(data.name.toLowerCase())
+                    )
+                    .slice(0, 5)
+                    .map((flower) => (
+                      <div
+                        key={flower.name}
+                        className="px-3 py-2 cursor-pointer hover:bg-gray-100 flex items-center gap-2"
+                        onClick={() => {
+                          onChange({
+                            ...data,
+                            name: flower.name,
+                            emoji: flower.emoji,
+                            color: data.color || flower.color,
+                            isStandardFlower: true,
+                          })
+                        }}
+                      >
+                        <span>{flower.emoji}</span>
+                        <span>{flower.name}</span>
+                      </div>
+                    ))}
+                </div>
+              )}
+            </div>
+            {errors.name && (
+              <div className="flex items-center gap-1 text-destructive text-sm">
+                <AlertCircle className="h-4 w-4" />
+                {errors.name}
+              </div>
+            )}
+          </div>
+
+          {/* Color */}
+          <div className="space-y-2">
+            <Label htmlFor="color">Kleur *</Label>
+            <Input
+              id="color"
+              placeholder="Bijv. Rood, Geel, Wit"
+              value={data.color}
+              onChange={(e) => handleFieldChange('color', e.target.value)}
+              className={errors.color ? "border-destructive" : ""}
+              required
+              autoComplete="off"
+            />
+            {errors.color && (
+              <div className="flex items-center gap-1 text-destructive text-sm">
+                <AlertCircle className="h-4 w-4" />
+                {errors.color}
+              </div>
+            )}
+          </div>
+
+          {/* Height */}
+          <div className="space-y-2">
+            <Label htmlFor="height">Hoogte (cm) *</Label>
+            <Input
+              id="height"
+              type="number"
+              placeholder="Bijv. 150"
+              value={data.height}
+              onChange={(e) => handleFieldChange('height', e.target.value)}
+              className={errors.height ? "border-destructive" : ""}
+              required
+              autoComplete="off"
+            />
+            {errors.height && (
+              <div className="flex items-center gap-1 text-destructive text-sm">
+                <AlertCircle className="h-4 w-4" />
+                {errors.height}
+              </div>
+            )}
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Advanced Fields (Collapsible) */}
+      {showAdvanced && (
+        <Collapsible open={isAdvancedOpen} onOpenChange={setIsAdvancedOpen}>
+          <CollapsibleTrigger asChild>
+            <Button variant="outline" className="w-full">
+              <span>Geavanceerde opties</span>
+              {isAdvancedOpen ? (
+                <ChevronUp className="h-4 w-4 ml-2" />
+              ) : (
+                <ChevronDown className="h-4 w-4 ml-2" />
+              )}
+            </Button>
+          </CollapsibleTrigger>
+          
+          <CollapsibleContent className="space-y-4 mt-4">
+            <Card>
+              <CardHeader>
+                <CardTitle>Aanvullende Informatie</CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                  <div className="space-y-2">
+                    <Label htmlFor="scientificName">Wetenschappelijke naam</Label>
+                    <Input
+                      id="scientificName"
+                      placeholder="Bijv. Rosa rubiginosa"
+                      value={data.scientificName}
+                      onChange={(e) => handleFieldChange('scientificName', e.target.value)}
+                      autoComplete="off"
+                    />
+                  </div>
+
+                  <div className="space-y-2">
+                    <Label htmlFor="latinName">Latijnse naam</Label>
+                    <Input
+                      id="latinName"
+                      placeholder="Bijv. Rosa"
+                      value={data.latinName}
+                      onChange={(e) => handleFieldChange('latinName', e.target.value)}
+                      autoComplete="off"
+                    />
+                  </div>
+
+                  <div className="space-y-2">
+                    <Label htmlFor="variety">Variëteit</Label>
+                    <Input
+                      id="variety"
+                      placeholder="Bijv. Red Eden"
+                      value={data.variety}
+                      onChange={(e) => handleFieldChange('variety', e.target.value)}
+                      autoComplete="off"
+                    />
+                  </div>
+
+                  <div className="space-y-2">
+                    <Label htmlFor="plantColor">Plant kleur</Label>
+                    <Input
+                      id="plantColor"
+                      placeholder="Bijv. Groen, Donkergroen"
+                      value={data.plantColor}
+                      onChange={(e) => handleFieldChange('plantColor', e.target.value)}
+                      autoComplete="off"
+                    />
+                  </div>
+
+                  <div className="space-y-2">
+                    <Label htmlFor="plantHeight">Plant hoogte (cm)</Label>
+                    <Input
+                      id="plantHeight"
+                      type="number"
+                      placeholder="Bijv. 80"
+                      value={data.plantHeight}
+                      onChange={(e) => handleFieldChange('plantHeight', e.target.value)}
+                      autoComplete="off"
+                    />
+                  </div>
+
+                  <div className="space-y-2">
+                    <Label htmlFor="plantsPerSqm">Planten per m²</Label>
+                    <Input
+                      id="plantsPerSqm"
+                      type="number"
+                      placeholder="Bijv. 4"
+                      value={data.plantsPerSqm}
+                      onChange={(e) => handleFieldChange('plantsPerSqm', e.target.value)}
+                      autoComplete="off"
+                    />
+                  </div>
+                </div>
+
+                <div className="space-y-2">
+                  <Label htmlFor="sunPreference">Zonvoorkeur</Label>
+                  <Select 
+                    value={data.sunPreference} 
+                    onValueChange={(value: 'full-sun' | 'partial-sun' | 'shade') => 
+                      handleFieldChange('sunPreference', value)
+                    }
+                  >
+                    <SelectTrigger>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="full-sun">Volle zon</SelectItem>
+                      <SelectItem value="partial-sun">Halfschaduw</SelectItem>
+                      <SelectItem value="shade">Schaduw</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                  <div className="space-y-2">
+                    <Label htmlFor="plantingDate">Plantdatum</Label>
+                    <Input
+                      id="plantingDate"
+                      type="date"
+                      value={data.plantingDate}
+                      onChange={(e) => handleFieldChange('plantingDate', e.target.value)}
+                    />
+                  </div>
+
+                  <div className="space-y-2">
+                    <Label htmlFor="expectedHarvestDate">Verwachte oogstdatum</Label>
+                    <Input
+                      id="expectedHarvestDate"
+                      type="date"
+                      value={data.expectedHarvestDate}
+                      onChange={(e) => handleFieldChange('expectedHarvestDate', e.target.value)}
+                    />
+                  </div>
+                </div>
+
+                <div className="space-y-2">
+                  <Label htmlFor="status">Status</Label>
+                  <Select 
+                    value={data.status} 
+                    onValueChange={(value: "gezond" | "aandacht_nodig" | "ziek" | "dood" | "geoogst") => 
+                      handleFieldChange('status', value)
+                    }
+                  >
+                    <SelectTrigger>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="gezond">Gezond</SelectItem>
+                      <SelectItem value="aandacht_nodig">Aandacht nodig</SelectItem>
+                      <SelectItem value="ziek">Ziek</SelectItem>
+                      <SelectItem value="dood">Dood</SelectItem>
+                      <SelectItem value="geoogst">Geoogst</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+
+                <div className="space-y-2">
+                  <Label htmlFor="notes">Opmerkingen</Label>
+                  <Textarea
+                    id="notes"
+                    placeholder="Aanvullende opmerkingen over deze plant..."
+                    value={data.notes}
+                    onChange={(e) => handleFieldChange('notes', e.target.value)}
+                    rows={3}
+                  />
+                </div>
+
+                <div className="space-y-2">
+                  <Label htmlFor="careInstructions">Verzorgingsinstructies</Label>
+                  <Textarea
+                    id="careInstructions"
+                    placeholder="Specifieke verzorgingsinstructies..."
+                    value={data.careInstructions}
+                    onChange={(e) => handleFieldChange('careInstructions', e.target.value)}
+                    rows={3}
+                  />
+                </div>
+
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                  <div className="space-y-2">
+                    <Label htmlFor="wateringFrequency">Water frequentie (dagen)</Label>
+                    <Input
+                      id="wateringFrequency"
+                      type="number"
+                      placeholder="Bijv. 3"
+                      value={data.wateringFrequency}
+                      onChange={(e) => handleFieldChange('wateringFrequency', e.target.value)}
+                      autoComplete="off"
+                    />
+                  </div>
+
+                  <div className="space-y-2">
+                    <Label htmlFor="fertilizerSchedule">Bemestingsschema</Label>
+                    <Input
+                      id="fertilizerSchedule"
+                      placeholder="Bijv. Wekelijks"
+                      value={data.fertilizerSchedule}
+                      onChange={(e) => handleFieldChange('fertilizerSchedule', e.target.value)}
+                      autoComplete="off"
+                    />
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+          </CollapsibleContent>
+        </Collapsible>
+      )}
+
+      {/* Submit buttons */}
+      <div className="flex gap-3 pt-6">
+        <Button 
+          type="submit" 
+          disabled={isSubmitting || !data.name.trim() || !data.color.trim() || !data.height.trim()}
+          className="flex-1"
+        >
+          {isSubmitting ? 'Bezig...' : submitLabel}
+        </Button>
+        {onReset && (
+          <Button type="reset" variant="outline">
+            Reset
+          </Button>
+        )}
+      </div>
+    </form>
+  )
+}
+
+// Helper function to create initial form data
+export function createInitialPlantFormData(): PlantFormData {
+  return {
+    name: "",
+    color: "",
+    height: "",
+    scientificName: "",
+    latinName: "",
+    variety: "",
+    plantColor: "",
+    plantHeight: "",
+    plantsPerSqm: "4",
+    sunPreference: 'partial-sun',
+    plantingDate: "",
+    expectedHarvestDate: "",
+    status: "gezond",
+    notes: "",
+    careInstructions: "",
+    wateringFrequency: "",
+    fertilizerSchedule: "",
+    emoji: DEFAULT_FLOWER_EMOJI,
+    isStandardFlower: false,
+  }
+}


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Implements UI cleanup and enhances task management with logbook integration and detailed editing.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
This PR addresses user feedback by removing redundant navigation elements ("Dashboard" and "Taken" buttons) for a cleaner interface. It also introduces two key features: automatically creating a logbook entry when a task is marked as complete, and enabling users to view and edit task details by double-clicking on a task card. These changes improve usability and streamline the task management workflow.

---
<a href="https://cursor.com/background-agent?bcId=bc-445d91c3-27b1-45d5-a67d-83374f3d5d8a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-445d91c3-27b1-45d5-a67d-83374f3d5d8a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>