### PR TITLE
Update navigation and fix back button behavior

### DIFF
--- a/app/gardens/[id]/plant-beds/[bedId]/plants/[plantId]/edit/page.tsx
+++ b/app/gardens/[id]/plant-beds/[bedId]/plants/[plantId]/edit/page.tsx
@@ -194,7 +194,7 @@ export default function EditPlantPage() {
         description: `Plant "${plantData.name}" is succesvol bijgewerkt.`,
       })
 
-      router.push(`/gardens/${params.id}/plant-beds/${params.bedId}/plants`)
+      router.push(`/gardens/${params.id}/plantvak-view/${params.bedId}`)
     } catch (error) {
       console.error('Error updating plant:', error)
       toast({
@@ -224,7 +224,7 @@ export default function EditPlantPage() {
         description: `Plant "${plant.name}" is succesvol verwijderd.`,
       })
 
-      router.push(`/gardens/${params.id}/plant-beds/${params.bedId}/plants`)
+      router.push(`/gardens/${params.id}/plantvak-view/${params.bedId}`)
     } catch (error) {
       console.error('Error deleting plant:', error)
       toast({
@@ -277,9 +277,9 @@ export default function EditPlantPage() {
           <h2 className="text-2xl font-bold text-gray-900 mb-4">Plant niet gevonden</h2>
           <p className="text-gray-600 mb-6">De opgevraagde plant bestaat niet of is verwijderd.</p>
           <Button asChild>
-            <Link href={`/gardens/${params.id}/plant-beds/${params.bedId}/plants`}>
+            <Link href={`/gardens/${params.id}/plantvak-view/${params.bedId}`}>
               <ArrowLeft className="h-4 w-4 mr-2" />
-              Terug naar planten
+              Terug naar plantvak
             </Link>
           </Button>
         </div>
@@ -291,9 +291,9 @@ export default function EditPlantPage() {
     <div className="container mx-auto p-6 max-w-4xl">
       {/* Back button */}
       <Button asChild variant="ghost" className="mb-6">
-        <Link href={`/gardens/${params.id}/plant-beds/${params.bedId}/plants`}>
+        <Link href={`/gardens/${params.id}/plantvak-view/${params.bedId}`}>
           <ArrowLeft className="h-4 w-4 mr-2" />
-          Terug naar planten
+          Terug naar plantvak
         </Link>
       </Button>
 

--- a/app/gardens/[id]/plant-beds/[bedId]/plants/new/page.tsx
+++ b/app/gardens/[id]/plant-beds/[bedId]/plants/new/page.tsx
@@ -178,7 +178,7 @@ export default function NewPlantPage() {
         description: `Plant "${plantData.name}" is succesvol toegevoegd aan ${plantBed.name}.`,
       })
       
-      router.push(`/gardens/${garden?.id}/plant-beds/${plantBed.id}/plants`)
+      router.push(`/gardens/${garden?.id}/plantvak-view/${plantBed.id}`)
     } catch (error) {
       console.error('Error creating plant:', error)
       toast({
@@ -232,9 +232,9 @@ export default function NewPlantPage() {
     <div className="container mx-auto p-6 max-w-4xl">
       {/* Back button */}
       <Button asChild variant="ghost" className="mb-6">
-        <Link href={`/gardens/${garden.id}/plant-beds/${plantBed.id}/plants`}>
+        <Link href={`/gardens/${garden.id}/plantvak-view/${plantBed.id}`}>
           <ArrowLeft className="h-4 w-4 mr-2" />
-          Terug naar planten
+          Terug naar plantvak
         </Link>
       </Button>
 

--- a/app/gardens/[id]/plantvak-view/[bedId]/page.tsx
+++ b/app/gardens/[id]/plantvak-view/[bedId]/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useRef, useCallback } from "react"
 import { useParams, useRouter } from "next/navigation"
+import { useNavigation } from "@/hooks/use-navigation"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
@@ -181,6 +182,7 @@ const FLOWER_STATUS_OPTIONS = [
 export default function PlantBedViewPage() {
   const router = useRouter()
   const params = useParams()
+  const { goBack } = useNavigation()
   // toast removed - no more notifications
   
   const [garden, setGarden] = useState<Garden | null>(null)
@@ -255,16 +257,7 @@ export default function PlantBedViewPage() {
   
   const containerRef = useRef<HTMLDivElement>(null)
 
-  // Smart navigation - go back to where user came from
-  const handleBackNavigation = () => {
-    // Check if user can go back in browser history
-    if (window.history.length > 1) {
-      router.back()
-    } else {
-      // Fallback to garden page
-      router.push(`/gardens/${params.id}`)
-    }
-  }
+  // Use consistent navigation hook for back navigation
 
   // Load tasks for this plant bed and its plants
   const loadTasks = async () => {
@@ -1531,7 +1524,7 @@ export default function PlantBedViewPage() {
           <Leaf className="h-12 w-12 mx-auto text-gray-400 mb-4" />
           <h3 className="text-lg font-medium text-gray-900 mb-2">Plantvak niet gevonden</h3>
           <p className="text-gray-600 mb-4">Het plantvak dat je zoekt bestaat niet.</p>
-          <Button onClick={handleBackNavigation} className="bg-green-600 hover:bg-green-700">
+          <Button onClick={goBack} className="bg-green-600 hover:bg-green-700">
             <ArrowLeft className="h-4 w-4 mr-2" />
             Terug
           </Button>
@@ -1548,7 +1541,7 @@ export default function PlantBedViewPage() {
           <Button
             variant="ghost"
             size="sm"
-            onClick={handleBackNavigation}
+            onClick={goBack}
             className="flex items-center gap-2"
           >
             <ArrowLeft className="h-4 w-4" />

--- a/apps/web/app/gardens/[id]/plant-beds/[bedId]/plants/new/page.tsx
+++ b/apps/web/app/gardens/[id]/plant-beds/[bedId]/plants/new/page.tsx
@@ -117,7 +117,7 @@ export default function NewPlantPage() {
         title: "Plant toegevoegd!",
         description: `Plant "${newPlant.name}" is succesvol toegevoegd aan ${plantBed.name}.`,
       })
-      router.push(`/gardens/${garden?.id}/plant-beds/${plantBed.id}/plants`)
+      router.push(`/gardens/${garden?.id}/plantvak-view/${plantBed.id}`)
     } catch (err) {
       console.error("Error creating plant:", err)
       toast({
@@ -166,11 +166,11 @@ export default function NewPlantPage() {
           <Button
             variant="ghost"
             size="sm"
-            onClick={() => router.push(`/gardens/${garden.id}/plant-beds/${plantBed.id}/plants`)}
+            onClick={() => router.push(`/gardens/${garden.id}/plantvak-view/${plantBed.id}`)}
             className="flex items-center gap-2"
           >
             <ArrowLeft className="h-4 w-4" />
-            {plantBed.name} - Planten
+            {plantBed.name} - Plantvak
           </Button>
 
           <div>

--- a/apps/web/app/gardens/[id]/plant-beds/page.tsx
+++ b/apps/web/app/gardens/[id]/plant-beds/page.tsx
@@ -230,10 +230,10 @@ export default function PlantBedsPage() {
                       Bekijk
                     </Button>
                   </Link>
-                  <Link href={`/gardens/${garden.id}/plant-beds/${bed.id}/plants`}>
+                  <Link href={`/gardens/${garden.id}/plantvak-view/${bed.id}`}>
                     <Button size="sm" className="bg-green-600 hover:bg-green-700">
                       <Leaf className="h-3 w-3 mr-1" />
-                      Planten
+                      Plantvak
                     </Button>
                   </Link>
                 </div>


### PR DESCRIPTION
Replace plant list navigation with the new plant bed view and standardize back navigation across the app.

This change ensures that all links pointing to a plant bed's details now direct to the visual `plantvak-view` page. It also unifies back navigation logic using the `useNavigation` hook, providing a consistent user experience where 'back' always returns to the previously visited page.

---
<a href="https://cursor.com/background-agent?bcId=bc-87c3b05b-f55d-4d9b-b156-d01fb6737072">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-87c3b05b-f55d-4d9b-b156-d01fb6737072">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>