### PR TITLE
Fix plant tasks not showing in list

### DIFF
--- a/lib/services/task.service.ts
+++ b/lib/services/task.service.ts
@@ -213,14 +213,19 @@ export class TaskService {
       // Combine all tasks
       let transformedData: TaskWithPlantInfo[] = [...plantTasks, ...plantBedTasks]
 
-      // Apply consistent sorting: incomplete first (by due date), then completed at bottom
+      // Apply consistent sorting: incomplete first (by due date + priority), then completed at bottom
       transformedData.sort((a, b) => {
         // Completed tasks go to bottom
         if (a.completed && !b.completed) return 1
         if (!a.completed && b.completed) return -1
         
-        // Within same completion status, sort by due date
-        return new Date(a.due_date).getTime() - new Date(b.due_date).getTime()
+        // Within same completion status, sort by due date first
+        const dateCompare = new Date(a.due_date).getTime() - new Date(b.due_date).getTime()
+        if (dateCompare !== 0) return dateCompare
+        
+        // Then by priority (high=3, medium=2, low=1)
+        const priorityWeight = { high: 3, medium: 2, low: 1 }
+        return (priorityWeight[b.priority] || 2) - (priorityWeight[a.priority] || 2)
       })
 
       // Apply client-side filtering if needed
@@ -348,19 +353,19 @@ export class TaskService {
 
       const transformedData: WeeklyTask[] = [...plantTasks, ...plantBedTasks]
 
-      // Apply consistent sorting: incomplete first (by due date), then completed at bottom
+      // Apply consistent sorting: incomplete first (by due date + priority), then completed at bottom
       transformedData.sort((a, b) => {
         // Completed tasks go to bottom
         if (a.completed && !b.completed) return 1
         if (!a.completed && b.completed) return -1
         
-        // Within same completion status, sort by due date, then priority
+        // Within same completion status, sort by due date first
         const dateCompare = new Date(a.due_date).getTime() - new Date(b.due_date).getTime()
         if (dateCompare !== 0) return dateCompare
         
-        // Higher priority first (high=3, medium=2, low=1)
+        // Then by priority (high=3, medium=2, low=1)
         const priorityWeight = { high: 3, medium: 2, low: 1 }
-        return priorityWeight[b.priority] - priorityWeight[a.priority]
+        return (priorityWeight[b.priority] || 2) - (priorityWeight[a.priority] || 2)
       })
 
       return { data: transformedData, error: null }


### PR DESCRIPTION
Fix: Plantvak tasks now appear in task lists and summaries.

The previous task fetching queries in `TaskService` used `plants!inner` joins, which inadvertently excluded tasks associated only with `plant_beds` (plantvak tasks) and not specific `plants`. This PR modifies `getTasksWithPlantInfo`, `getWeeklyTasks`, and `getTaskSummary` to fetch both plant-specific tasks and plant-bed-specific tasks, then combines them for a complete view.

---
<a href="https://cursor.com/background-agent?bcId=bc-a3492b81-35f4-48c9-834d-7c9c2863f6cb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a3492b81-35f4-48c9-834d-7c9c2863f6cb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>