### PR TITLE
Enable lint for unused variables

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,7 +1,7 @@
 {
   "extends": ["next/core-web-vitals", "next/typescript"],
   "rules": {
-    "@typescript-eslint/no-unused-vars": "off",
+    "@typescript-eslint/no-unused-vars": "warn",
     "@typescript-eslint/no-explicit-any": "warn",
     "react/no-unescaped-entities": "off",
     "@next/next/no-img-element": "off",

--- a/lib/services/task.service.ts
+++ b/lib/services/task.service.ts
@@ -90,7 +90,7 @@ export class TaskService {
 
       if (error) throw error
       return { data: data || [], error: null }
-    } catch (error) {
+    } catch {
       // Secure error handling for banking standards - no console logging in production
       return { data: [], error: 'Failed to fetch tasks' }
     }
@@ -139,7 +139,7 @@ export class TaskService {
       }
 
       return { data: summary, error: null }
-    } catch (error) {
+    } catch {
       // Secure error handling for banking standards - no console logging in production
       return { data: null, error: 'Failed to fetch task stats' }
     }
@@ -184,7 +184,7 @@ export class TaskService {
       })
 
       return { data: Object.values(plantStats), error: null }
-    } catch (error) {
+    } catch {
       // Secure error handling for banking standards - no console logging in production
       return { data: [], error: 'Failed to fetch plant task stats' }
     }
@@ -204,7 +204,7 @@ export class TaskService {
 
       if (error) throw error
       return { data: data, error: null }
-    } catch (error) {
+    } catch {
       // Secure error handling for banking standards - no console logging in production
       return { data: null, error: 'Failed to create recurring tasks' }
     }
@@ -220,7 +220,7 @@ export class TaskService {
 
       if (error) throw error
       return { error: null }
-    } catch (error) {
+    } catch {
       // Secure error handling for banking standards - no console logging in production
       return { error: 'Failed to bulk complete tasks' }
     }
@@ -235,7 +235,7 @@ export class TaskService {
 
       if (error) throw error
       return { error: null }
-    } catch (error) {
+    } catch {
       // Secure error handling for banking standards - no console logging in production
       return { error: 'Failed to bulk delete tasks' }
     }
@@ -266,7 +266,7 @@ export class TaskService {
       }))
 
       return { data: transformedData, error: null }
-    } catch (error) {
+    } catch {
       // Secure error handling for banking standards - no console logging in production
       return { data: [], error: 'Failed to fetch today tasks' }
     }
@@ -294,7 +294,7 @@ export class TaskService {
       }))
 
       return { data: transformedData, error: null }
-    } catch (error) {
+    } catch {
       // Secure error handling for banking standards - no console logging in production
       return { data: [], error: 'Failed to fetch overdue tasks' }
     }
@@ -321,7 +321,7 @@ export class TaskService {
       }))
 
       return { data: transformedData, error: null }
-    } catch (error) {
+    } catch {
       // Secure error handling for banking standards - no console logging in production
       return { data: [], error: 'Failed to fetch plant bed tasks' }
     }
@@ -344,7 +344,7 @@ export class TaskService {
       }
 
       return { data: stats, error: null }
-    } catch (error) {
+    } catch {
       // Secure error handling for banking standards - no console logging in production
       return { data: null, error: 'Failed to fetch plant bed task stats' }
     }
@@ -367,7 +367,7 @@ export class TaskService {
 
       if (error) throw error
       return { data, error: null }
-    } catch (error) {
+    } catch {
       // Secure error handling for banking standards - no console logging in production
       return { data: null, error: 'Failed to create task' }
     }
@@ -384,7 +384,7 @@ export class TaskService {
 
       if (error) throw error
       return { data, error: null }
-    } catch (error) {
+    } catch {
       // Secure error handling for banking standards - no console logging in production
       return { data: null, error: 'Failed to update task' }
     }
@@ -399,13 +399,13 @@ export class TaskService {
 
       if (error) throw error
       return { error: null }
-    } catch (error) {
+    } catch {
       // Secure error handling for banking standards - no console logging in production
       return { error: 'Failed to delete task' }
     }
   }
 
-  static async getWeeklyCalendar(weekStart: Date, user?: Record<string, unknown>): Promise<{ data: WeeklyCalendar; error: string | null }> {
+  static async getWeeklyCalendar(weekStart: Date): Promise<{ data: WeeklyCalendar; error: string | null }> {
     try {
       const weekEnd = new Date(weekStart)
       weekEnd.setDate(weekEnd.getDate() + 6)
@@ -440,7 +440,7 @@ export class TaskService {
       }
 
       return { data: calendarData, error: null }
-    } catch (error) {
+    } catch {
       // Secure error handling for banking standards - no console logging in production
       return { data: null, error: 'Failed to fetch weekly calendar' }
     }

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -56,7 +56,7 @@ export async function uploadImage(file: File, folder: string = 'plants'): Promis
     const filePath = `${folder}/${fileName}`
 
     // Upload file to storage
-    const { data, error } = await supabase.storage
+    const { error } = await supabase.storage
       .from('plant-images')
       .upload(filePath, file, {
         cacheControl: '3600',
@@ -80,7 +80,7 @@ export async function uploadImage(file: File, folder: string = 'plants'): Promis
       success: true,
       url: publicUrl
     }
-  } catch (error) {
+  } catch {
     // Console logging removed for banking standards.error('Upload error:', error)
     return {
       success: false,
@@ -114,7 +114,7 @@ export async function deleteImage(url: string): Promise<boolean> {
     }
 
     return true
-  } catch (error) {
+  } catch {
     // Console logging removed for banking standards.error('Delete error:', error)
     return false
   }

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -37,7 +37,7 @@ export const secureSupabaseCall = async <T>(
 ): Promise<T> => {
   try {
     return await operation()
-  } catch (error) {
+  } catch {
     // Secure error handling for banking standards - no console logging in production
     return fallback
   }
@@ -109,7 +109,7 @@ export interface PlantBedWithPosition {
   updated_at: string
 }
 
-export interface ApiResponse<T = any> {
+export interface ApiResponse<T = unknown> {
   success: boolean
   data?: T
   error?: string


### PR DESCRIPTION
## Summary
- warn on unused variables in ESLint config
- remove unused catch parameters and data destructures
- clean up generic type usage in Supabase helper

## Testing
- `npx eslint lib/services/task.service.ts lib/storage.ts lib/supabase.ts`
- `npm test` *(fails: Cannot find module '@/lib/security/garden-access', TypeError in use-toast tests, and others)*

------
https://chatgpt.com/codex/tasks/task_e_68a0141f6f1c8326b69d7f39b29f076c