### PR TITLE
Disable JS compilation and exclude JS scripts

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "lib": ["dom", "dom.iterable", "esnext"],
-    "allowJs": true,
+    "allowJs": false,
     "target": "ES6",
     "skipLibCheck": true,
     "strict": true,
@@ -28,6 +28,10 @@
     "node_modules",
     "apps/mobile/**/*",
     "packages/**/*",
-    "*.config.js"
+    "*.config.js",
+    "build-success.js",
+    "jest.config.js",
+    "jest.setup.js",
+    "scripts/**/*.js"
   ]
 }


### PR DESCRIPTION
## Summary
- disable JavaScript compilation by setting `allowJs` to `false`
- explicitly exclude residual `.js` helper and config files from TypeScript processing

## Testing
- `npm run type-check` (fails: many existing TS errors)
- `npm test` (fails: 16 failed, 71 passed)


------
https://chatgpt.com/codex/tasks/task_e_68a014216d8883268ab7f8504da66a16