### PR TITLE
feat(ci): enable agent-based test fixes

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -97,7 +97,19 @@ jobs:
         continue-on-error: false
 
       - name: 🧪 Jest - Unit & Integration Tests (CRITICAL)
-        run: npm run test:ci
+        run: |
+          set -e
+          attempts=0
+          max_attempts=3
+          until npm run test:ci 2>&1 | tee test-log.txt; do
+            attempts=$((attempts+1))
+            if [ $attempts -ge $max_attempts ]; then
+              echo "Tests failed after $attempts attempts"
+              exit 1
+            fi
+            echo "📨 Sending logs to agent for patch..."
+            bash scripts/agent-fix-tests.sh || true
+          done
         env:
           CI: true
         continue-on-error: false

--- a/cursor-config.md
+++ b/cursor-config.md
@@ -46,3 +46,9 @@
 - [ ] Security‑impact beoordeeld (secrets, policies, fouten)
 - [ ] Documentatie bijgewerkt
 - [ ] CI/CD status gecontroleerd en deployment‑impact beschreven
+
+## 🔁 Geautomatiseerde Testherstel
+- CI slaat testuitvoer op in `test-log.txt`.
+- Bij falende tests roept de pipeline `scripts/agent-fix-tests.sh` aan.
+- Het script verstuurt de log naar een generieke agent-API (`AGENT_API_URL`) en past de ontvangen patch toe.
+- De pipeline herhaalt de tests tot ze slagen of de maximale pogingen zijn bereikt.

--- a/scripts/agent-fix-tests.sh
+++ b/scripts/agent-fix-tests.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -euo pipefail
+
+# Sends the latest test log to a generic agent API and applies the returned patch.
+
+API_URL="${AGENT_API_URL:-}"
+
+if [[ -z "$API_URL" ]]; then
+  echo "AGENT_API_URL not set; skipping agent fix."
+  exit 0
+fi
+
+if [[ ! -f test-log.txt ]]; then
+  echo "test-log.txt not found; nothing to send."
+  exit 0
+fi
+
+echo "Sending test log to agent at $API_URL..."
+PATCH=$(curl -sS -X POST "$API_URL" -H "Content-Type: text/plain" --data-binary @test-log.txt || true)
+
+if [[ -z "$PATCH" ]]; then
+  echo "No patch received from agent."
+  exit 0
+fi
+
+echo "Applying patch from agent..."
+if git apply <<<"$PATCH"; then
+  echo "Patch applied successfully."
+else
+  echo "Failed to apply patch."
+fi
+


### PR DESCRIPTION
## Summary
- log Jest output to `test-log.txt` and retry failed tests with an agent helper
- add `scripts/agent-fix-tests.sh` to send logs to a generic agent API and apply returned patch
- document automated test-repair loop in `cursor-config.md`

## Testing
- `npm run lint`
- `npm run type-check` *(fails: TS2554, TS2322, TS2739, TS2345)*
- `npm run test:ci` *(fails: 16 failing suites)*

------
https://chatgpt.com/codex/tasks/task_e_68a0192d69588326bc40a073414bf8ec