### PR TITLE
test: use real components in simple components tests

### DIFF
--- a/__tests__/unit/components/simple-components.test.tsx
+++ b/__tests__/unit/components/simple-components.test.tsx
@@ -1,468 +1,57 @@
-import React from 'react';
-import { render, screen } from '@testing-library/react';
-import '@testing-library/jest-dom';
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import '@testing-library/jest-dom'
 
-// Mock Next.js components
+// Mock Next.js navigation hooks
 jest.mock('next/navigation', () => ({
   useRouter: () => ({
     push: jest.fn(),
     replace: jest.fn(),
     prefetch: jest.fn(),
   }),
-}));
+  usePathname: () => '/',
+}))
 
-// Test simple component files
+// Mock auth hook for navigation components
+jest.mock('@/hooks/use-supabase-auth', () => ({
+  useAuth: () => ({
+    user: null,
+    signOut: jest.fn(),
+    isAdmin: jest.fn(() => false),
+  }),
+}))
+
+// Mock BankingNavigation used within AuthNavigation
+jest.mock('@/components/navigation', () => ({
+  BankingNavigation: () => <nav data-testid="banking-navigation" />,
+}))
+
 describe('Simple Component Files', () => {
-  describe('components/error-boundary.tsx', () => {
-    it('should render error boundary component', () => {
-      const ErrorBoundaryComponent = ({ children }: { children: React.ReactNode }) => (
-        <div className="error-boundary">
-          {children}
-        </div>
-      );
-      
-      render(
-        <ErrorBoundaryComponent>
-          <div>Content</div>
-        </ErrorBoundaryComponent>
-      );
-      expect(screen.getByText('Content')).toBeInTheDocument();
-    });
-  });
+  it('renders the real ErrorBoundary component', async () => {
+    const { ErrorBoundary } = await import('@/components/error-boundary')
+    render(
+      <ErrorBoundary>
+        <div>Test content</div>
+      </ErrorBoundary>
+    )
+    expect(screen.getByText('Test content')).toBeInTheDocument()
+  })
 
-  describe('components/theme-toggle.tsx', () => {
-    it('should render theme toggle component', () => {
-      const ThemeToggleComponent = () => {
-        const [theme, setTheme] = React.useState('light');
-        
-        return (
-          <button
-            onClick={() => setTheme(theme === 'light' ? 'dark' : 'light')}
-            className="p-2 rounded border"
-          >
-            Current theme: {theme}
-          </button>
-        );
-      };
-      
-      render(<ThemeToggleComponent />);
-      expect(screen.getByText('Current theme: light')).toBeInTheDocument();
-    });
-  });
+  it('renders the real ThemeToggle component', async () => {
+    const { ThemeToggle } = await import('@/components/theme-toggle')
+    render(<ThemeToggle />)
+    expect(screen.getByRole('button')).toBeInTheDocument()
+  })
 
-  describe('components/plant-photo-gallery.tsx', () => {
-    it('should render plant photo gallery component', () => {
-      const PlantPhotoGalleryComponent = () => (
-        <div className="grid grid-cols-3 gap-4" data-testid="photo-gallery">
-          <div className="aspect-square bg-gray-200 rounded"></div>
-          <div className="aspect-square bg-gray-200 rounded"></div>
-          <div className="aspect-square bg-gray-200 rounded"></div>
-        </div>
-      );
-      
-      render(<PlantPhotoGalleryComponent />);
-      expect(screen.getByTestId('photo-gallery')).toBeInTheDocument();
-    });
-  });
+  it('renders the real PlantPhotoGallery component', async () => {
+    const { PlantPhotoGallery } = await import('@/components/plant-photo-gallery')
+    render(<PlantPhotoGallery plantId="test-plant" plantName="Test Plant" />)
+    expect(screen.getByText(/Foto's van/i)).toBeInTheDocument()
+  })
 
-  describe('components/admin/create-user-dialog.tsx', () => {
-    it('should render create user dialog component', () => {
-      const CreateUserDialogComponent = () => (
-        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center">
-          <div className="bg-white p-6 rounded-lg">
-            <h2 className="text-lg font-medium mb-4">Create New User</h2>
-            <form className="space-y-4">
-              <div>
-                <label htmlFor="email" className="block text-sm font-medium">Email</label>
-                <input
-                  type="email"
-                  id="email"
-                  className="mt-1 block w-full border border-gray-300 rounded-md px-3 py-2"
-                />
-              </div>
-              <div className="flex space-x-2">
-                <button type="submit" className="bg-blue-500 text-white px-4 py-2 rounded">
-                  Create
-                </button>
-                <button type="button" className="bg-gray-300 text-gray-700 px-4 py-2 rounded">
-                  Cancel
-                </button>
-              </div>
-            </form>
-          </div>
-        </div>
-      );
-      
-      render(<CreateUserDialogComponent />);
-      expect(screen.getByText('Create New User')).toBeInTheDocument();
-      expect(screen.getByText('Email')).toBeInTheDocument();
-      expect(screen.getByText('Create')).toBeInTheDocument();
-      expect(screen.getByText('Cancel')).toBeInTheDocument();
-    });
-  });
-
-  describe('components/admin/edit-user-dialog.tsx', () => {
-    it('should render edit user dialog component', () => {
-      const EditUserDialogComponent = () => (
-        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center">
-          <div className="bg-white p-6 rounded-lg">
-            <h2 className="text-lg font-medium mb-4">Edit User</h2>
-            <form className="space-y-4">
-              <div>
-                <label htmlFor="name" className="block text-sm font-medium">Name</label>
-                <input
-                  type="text"
-                  id="name"
-                  className="mt-1 block w-full border border-gray-300 rounded-md px-3 py-2"
-                />
-              </div>
-              <div className="flex space-x-2">
-                <button type="submit" className="bg-blue-500 text-white px-4 py-2 rounded">
-                  Save
-                </button>
-                <button type="button" className="bg-gray-300 text-gray-700 px-4 py-2 rounded">
-                  Cancel
-                </button>
-              </div>
-            </form>
-          </div>
-        </div>
-      );
-      
-      render(<EditUserDialogComponent />);
-      expect(screen.getByText('Edit User')).toBeInTheDocument();
-      expect(screen.getByText('Name')).toBeInTheDocument();
-      expect(screen.getByText('Save')).toBeInTheDocument();
-      expect(screen.getByText('Cancel')).toBeInTheDocument();
-    });
-  });
-
-  describe('components/admin/garden-access-manager.tsx', () => {
-    it('should render garden access manager component', () => {
-      const GardenAccessManagerComponent = () => (
-        <div className="space-y-4">
-          <h2 className="text-lg font-medium">Garden Access Management</h2>
-          <div className="border rounded-lg p-4">
-            <p className="text-gray-600">Manage user access to gardens</p>
-          </div>
-        </div>
-      );
-      
-      render(<GardenAccessManagerComponent />);
-      expect(screen.getByText('Garden Access Management')).toBeInTheDocument();
-      expect(screen.getByText('Manage user access to gardens')).toBeInTheDocument();
-    });
-  });
-
-  describe('components/auth/force-password-change.tsx', () => {
-    it('should render force password change component', () => {
-      const ForcePasswordChangeComponent = () => (
-        <div className="max-w-md mx-auto p-6">
-          <h2 className="text-lg font-medium mb-4">Change Password Required</h2>
-          <form className="space-y-4">
-            <div>
-              <label htmlFor="newPassword" className="block text-sm font-medium">New Password</label>
-              <input
-                type="password"
-                id="newPassword"
-                className="mt-1 block w-full border border-gray-300 rounded-md px-3 py-2"
-              />
-            </div>
-            <button type="submit" className="w-full bg-blue-500 text-white px-4 py-2 rounded">
-              Change Password
-            </button>
-          </form>
-        </div>
-      );
-      
-      render(<ForcePasswordChangeComponent />);
-      expect(screen.getByText('Change Password Required')).toBeInTheDocument();
-      expect(screen.getByText('New Password')).toBeInTheDocument();
-      expect(screen.getByText('Change Password')).toBeInTheDocument();
-    });
-  });
-
-  describe('components/auth/protected-route.tsx', () => {
-    it('should render protected route component', () => {
-      const ProtectedRouteComponent = ({ children }: { children: React.ReactNode }) => (
-        <div className="protected-route">
-          <div className="auth-check">Authentication check passed</div>
-          {children}
-        </div>
-      );
-      
-      render(
-        <ProtectedRouteComponent>
-          <div>Protected Content</div>
-        </ProtectedRouteComponent>
-      );
-      expect(screen.getByText('Authentication check passed')).toBeInTheDocument();
-      expect(screen.getByText('Protected Content')).toBeInTheDocument();
-    });
-  });
-
-  describe('components/auth/auth-provider.tsx', () => {
-    it('should render auth provider component', () => {
-      const AuthProviderComponent = ({ children }: { children: React.ReactNode }) => (
-        <div className="auth-provider">
-          <div className="auth-context">Auth context loaded</div>
-          {children}
-        </div>
-      );
-      
-      render(
-        <AuthProviderComponent>
-          <div>Auth Content</div>
-        </AuthProviderComponent>
-      );
-      expect(screen.getByText('Auth context loaded')).toBeInTheDocument();
-      expect(screen.getByText('Auth Content')).toBeInTheDocument();
-    });
-  });
-
-  describe('components/auth/authenticated-route.tsx', () => {
-    it('should render authenticated route component', () => {
-      const AuthenticatedRouteComponent = ({ children }: { children: React.ReactNode }) => (
-        <div className="authenticated-route">
-          <div className="auth-status">User authenticated</div>
-          {children}
-        </div>
-      );
-      
-      render(
-        <AuthenticatedRouteComponent>
-          <div>Authenticated Content</div>
-        </AuthenticatedRouteComponent>
-      );
-      expect(screen.getByText('User authenticated')).toBeInTheDocument();
-      expect(screen.getByText('Authenticated Content')).toBeInTheDocument();
-    });
-  });
-
-  describe('components/tasks/add-task-form.tsx', () => {
-    it('should render add task form component', () => {
-      const AddTaskFormComponent = () => (
-        <form className="space-y-4">
-          <div>
-            <label htmlFor="taskTitle" className="block text-sm font-medium">Task Title</label>
-            <input
-              type="text"
-              id="taskTitle"
-              className="mt-1 block w-full border border-gray-300 rounded-md px-3 py-2"
-            />
-          </div>
-          <div>
-            <label htmlFor="taskDescription" className="block text-sm font-medium">Description</label>
-            <textarea
-              id="taskDescription"
-              className="mt-1 block w-full border border-gray-300 rounded-md px-3 py-2"
-            />
-          </div>
-          <button type="submit" className="bg-green-500 text-white px-4 py-2 rounded">
-            Add Task
-          </button>
-        </form>
-      );
-      
-      render(<AddTaskFormComponent />);
-      expect(screen.getByText('Task Title')).toBeInTheDocument();
-      expect(screen.getByText('Description')).toBeInTheDocument();
-      expect(screen.getByText('Add Task')).toBeInTheDocument();
-    });
-  });
-
-  describe('components/tasks/task-card.tsx', () => {
-    it('should render task card component', () => {
-      const TaskCardComponent = () => (
-        <div className="border rounded-lg p-4">
-          <h3 className="text-lg font-medium">Sample Task</h3>
-          <p className="text-gray-600 mt-2">This is a sample task description</p>
-          <div className="mt-4 flex space-x-2">
-            <button className="bg-blue-500 text-white px-3 py-1 rounded text-sm">
-              Edit
-            </button>
-            <button className="bg-red-500 text-white px-3 py-1 rounded text-sm">
-              Delete
-            </button>
-          </div>
-        </div>
-      );
-      
-      render(<TaskCardComponent />);
-      expect(screen.getByText('Sample Task')).toBeInTheDocument();
-      expect(screen.getByText('This is a sample task description')).toBeInTheDocument();
-      expect(screen.getByText('Edit')).toBeInTheDocument();
-      expect(screen.getByText('Delete')).toBeInTheDocument();
-    });
-  });
-
-  describe('components/tasks/task-details-dialog.tsx', () => {
-    it('should render task details dialog component', () => {
-      const TaskDetailsDialogComponent = () => (
-        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center">
-          <div className="bg-white p-6 rounded-lg max-w-md w-full">
-            <h2 className="text-lg font-medium mb-4">Task Details</h2>
-            <div className="space-y-4">
-              <div>
-                <label className="block text-sm font-medium">Title</label>
-                <p className="mt-1">Sample Task Title</p>
-              </div>
-              <div>
-                <label className="block text-sm font-medium">Description</label>
-                <p className="mt-1">This is a detailed task description</p>
-              </div>
-              <div className="flex space-x-2">
-                <button className="bg-blue-500 text-white px-4 py-2 rounded">
-                  Edit
-                </button>
-                <button className="bg-gray-300 text-gray-700 px-4 py-2 rounded">
-                  Close
-                </button>
-              </div>
-            </div>
-          </div>
-        </div>
-      );
-      
-      render(<TaskDetailsDialogComponent />);
-      expect(screen.getByText('Task Details')).toBeInTheDocument();
-      expect(screen.getByText('Title')).toBeInTheDocument();
-      expect(screen.getByText('Sample Task Title')).toBeInTheDocument();
-      expect(screen.getByText('Description')).toBeInTheDocument();
-      expect(screen.getByText('This is a detailed task description')).toBeInTheDocument();
-      expect(screen.getByText('Edit')).toBeInTheDocument();
-      expect(screen.getByText('Close')).toBeInTheDocument();
-    });
-  });
-
-  describe('components/tasks/weekly-task-list.tsx', () => {
-    it('should render weekly task list component', () => {
-      const WeeklyTaskListComponent = () => (
-        <div className="space-y-4">
-          <h2 className="text-lg font-medium">Weekly Tasks</h2>
-          <div className="space-y-2">
-            <div className="border rounded p-3">
-              <h3 className="font-medium">Monday</h3>
-              <p className="text-sm text-gray-600">Water plants</p>
-            </div>
-            <div className="border rounded p-3">
-              <h3 className="font-medium">Tuesday</h3>
-              <p className="text-sm text-gray-600">Fertilize garden</p>
-            </div>
-          </div>
-        </div>
-      );
-      
-      render(<WeeklyTaskListComponent />);
-      expect(screen.getByText('Weekly Tasks')).toBeInTheDocument();
-      expect(screen.getByText('Monday')).toBeInTheDocument();
-      expect(screen.getByText('Water plants')).toBeInTheDocument();
-      expect(screen.getByText('Tuesday')).toBeInTheDocument();
-      expect(screen.getByText('Fertilize garden')).toBeInTheDocument();
-    });
-  });
-
-  describe('components/user/simple-tasks-view.tsx', () => {
-    it('should render simple tasks view component', () => {
-      const SimpleTasksViewComponent = () => (
-        <div className="space-y-4">
-          <h2 className="text-lg font-medium">My Tasks</h2>
-          <div className="space-y-2">
-            <div className="flex items-center space-x-2">
-              <input type="checkbox" id="task1" />
-              <label htmlFor="task1">Complete project</label>
-            </div>
-            <div className="flex items-center space-x-2">
-              <input type="checkbox" id="task2" />
-              <label htmlFor="task2">Review code</label>
-            </div>
-          </div>
-        </div>
-      );
-      
-      render(<SimpleTasksViewComponent />);
-      expect(screen.getByText('My Tasks')).toBeInTheDocument();
-      expect(screen.getByText('Complete project')).toBeInTheDocument();
-      expect(screen.getByText('Review code')).toBeInTheDocument();
-      expect(screen.getByLabelText('Complete project')).toBeInTheDocument();
-      expect(screen.getByLabelText('Review code')).toBeInTheDocument();
-    });
-  });
-
-  describe('components/navigation/auth-nav.tsx', () => {
-    it('should render auth navigation component', () => {
-      const AuthNavComponent = () => (
-        <nav className="flex space-x-4">
-          <a href="/login" className="text-blue-600 hover:text-blue-800">Login</a>
-          <a href="/register" className="text-blue-600 hover:text-blue-800">Register</a>
-        </nav>
-      );
-      
-      render(<AuthNavComponent />);
-      expect(screen.getByText('Login')).toBeInTheDocument();
-      expect(screen.getByText('Register')).toBeInTheDocument();
-    });
-  });
-
-  describe('components/navigation/navigation.tsx', () => {
-    it('should render main navigation component', () => {
-      const NavigationComponent = () => (
-        <nav className="flex space-x-6">
-          <a href="/" className="text-gray-600 hover:text-gray-900">Home</a>
-          <a href="/gardens" className="text-gray-600 hover:text-gray-900">Gardens</a>
-          <a href="/tasks" className="text-gray-600 hover:text-gray-900">Tasks</a>
-        </nav>
-      );
-      
-      render(<NavigationComponent />);
-      expect(screen.getByText('Home')).toBeInTheDocument();
-      expect(screen.getByText('Gardens')).toBeInTheDocument();
-      expect(screen.getByText('Tasks')).toBeInTheDocument();
-    });
-  });
-
-  describe('components/theme-toggle.tsx', () => {
-    it('should render theme toggle component', () => {
-      const ThemeToggleComponent = () => {
-        const [theme, setTheme] = React.useState('light');
-        
-        return (
-          <button
-            onClick={() => setTheme(theme === 'light' ? 'dark' : 'light')}
-            className="p-2 rounded border"
-            aria-label={`Switch to ${theme === 'light' ? 'dark' : 'light'} mode`}
-          >
-            {theme === 'light' ? '🌙' : '☀️'}
-          </button>
-        );
-      };
-      
-      render(<ThemeToggleComponent />);
-      expect(screen.getByLabelText('Switch to dark mode')).toBeInTheDocument();
-      expect(screen.getByText('🌙')).toBeInTheDocument();
-    });
-  });
-
-  describe('components/plant-photo-gallery.tsx', () => {
-    it('should render plant photo gallery component', () => {
-      const PlantPhotoGalleryComponent = () => (
-        <div className="space-y-4">
-          <h3 className="text-lg font-medium">Plant Photos</h3>
-          <div className="grid grid-cols-2 gap-4">
-            <div className="aspect-square bg-gray-200 rounded flex items-center justify-center">
-              <span className="text-gray-500">Photo 1</span>
-            </div>
-            <div className="aspect-square bg-gray-200 rounded flex items-center justify-center">
-              <span className="text-gray-500">Photo 2</span>
-            </div>
-          </div>
-        </div>
-      );
-      
-      render(<PlantPhotoGalleryComponent />);
-      expect(screen.getByText('Plant Photos')).toBeInTheDocument();
-      expect(screen.getByText('Photo 1')).toBeInTheDocument();
-      expect(screen.getByText('Photo 2')).toBeInTheDocument();
-    });
-  });
-});
+  it('renders AuthNavigation for unauthenticated users', async () => {
+    const { AuthNavigation } = await import('@/components/navigation/auth-nav')
+    render(<AuthNavigation />)
+    expect(screen.getByText('Inloggen')).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary
- replace inline stubs with real component imports in `simple-components.test.tsx`
- add auth and navigation mocks to render components
- verify rendering of `ErrorBoundary`, `ThemeToggle`, `PlantPhotoGallery` and `AuthNavigation`

## Testing
- `npm test __tests__/unit/components/simple-components.test.tsx`

------
https://chatgpt.com/codex/tasks/task_e_68a019a1a9188326b6a594fcaa25985d