### PR TITLE
test: add integration tests for basic api routes

### DIFF
--- a/__tests__/integration/api/health.test.ts
+++ b/__tests__/integration/api/health.test.ts
@@ -1,0 +1,36 @@
+import { GET, POST } from '@/app/api/health/route'
+import { NextResponse } from 'next/server'
+
+describe('Health API', () => {
+  it('GET /api/health returns healthy status', async () => {
+    const res = await GET()
+    expect(res.status).toBe(200)
+    const data = await res.json()
+    expect(data.status).toBe('healthy')
+  })
+
+  it('GET /api/health handles errors', async () => {
+    const originalJson = NextResponse.json
+    ;(NextResponse as any).json = () => {
+      throw new Error('Test error')
+    }
+    await expect(GET()).rejects.toThrow('Test error')
+    NextResponse.json = originalJson
+  })
+
+  it('POST /api/health returns healthy status', async () => {
+    const res = await POST()
+    expect(res.status).toBe(200)
+    const data = await res.json()
+    expect(data.method).toBe('POST')
+  })
+
+  it('POST /api/health handles errors', async () => {
+    const originalJson = NextResponse.json
+    ;(NextResponse as any).json = () => {
+      throw new Error('Test error')
+    }
+    await expect(POST()).rejects.toThrow('Test error')
+    NextResponse.json = originalJson
+  })
+})

--- a/__tests__/integration/api/plant-beds.test.ts
+++ b/__tests__/integration/api/plant-beds.test.ts
@@ -1,0 +1,73 @@
+import { GET } from '@/app/api/plant-beds/route'
+import { NextRequest } from 'next/server'
+
+jest.mock('@/lib/supabase', () => {
+  const mockQuery = {
+    select: jest.fn().mockReturnThis(),
+    order: jest.fn().mockReturnThis(),
+    eq: jest.fn().mockReturnThis(),
+    then: jest.fn(),
+  }
+  return {
+    supabase: {
+      from: jest.fn(() => mockQuery),
+      mockQuery,
+    },
+  }
+})
+
+jest.mock('@/lib/logger', () => ({
+  apiLogger: {
+    info: jest.fn(),
+    error: jest.fn(),
+  },
+}))
+
+const { supabase } = require('@/lib/supabase')
+const mockQuery = supabase.mockQuery
+
+function createMockNextRequest(url: string): NextRequest {
+  return {
+    headers: new Headers(),
+    nextUrl: new URL(url),
+  } as unknown as NextRequest
+}
+
+describe('Plant Beds API', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('GET /api/plant-beds returns plant beds', async () => {
+    const mockData = [{ id: 'bed-1' }]
+    mockQuery.then.mockImplementation((resolve) => resolve({ data: mockData, error: null }))
+
+    const request = createMockNextRequest('http://localhost:3000/api/plant-beds')
+    const res = await GET(request)
+    expect(res.status).toBe(200)
+    const data = await res.json()
+    expect(data).toEqual(mockData)
+  })
+
+  it('GET /api/plant-beds handles database errors', async () => {
+    mockQuery.then.mockImplementation((resolve) => resolve({ data: null, error: { message: 'Database error' } }))
+
+    const request = createMockNextRequest('http://localhost:3000/api/plant-beds')
+    const res = await GET(request)
+    expect(res.status).toBe(500)
+    const data = await res.json()
+    expect(data.error).toBe('Failed to fetch plant beds')
+  })
+
+  it('GET /api/plant-beds handles unexpected errors', async () => {
+    ;(supabase.from as jest.Mock).mockImplementation(() => {
+      throw new Error('Unexpected')
+    })
+
+    const request = createMockNextRequest('http://localhost:3000/api/plant-beds')
+    const res = await GET(request)
+    expect(res.status).toBe(500)
+    const data = await res.json()
+    expect(data.error).toBe('Internal server error')
+  })
+})

--- a/__tests__/integration/api/status.test.ts
+++ b/__tests__/integration/api/status.test.ts
@@ -1,0 +1,47 @@
+import { GET, HEAD } from '@/app/api/status/route'
+import { NextRequest, NextResponse } from 'next/server'
+
+function createMockNextRequest(url: string, headers: Record<string, string> = {}): NextRequest {
+  return {
+    headers: new Headers(headers),
+    nextUrl: new URL(url)
+  } as unknown as NextRequest
+}
+
+describe('Status API', () => {
+  it('GET /api/status returns operational status', async () => {
+    const request = createMockNextRequest('http://localhost:3000/api/status', {
+      'user-agent': 'jest',
+      accept: 'application/json'
+    })
+    const res = await GET(request)
+    expect(res.status).toBe(200)
+    const data = await res.json()
+    expect(data.status).toBe('operational')
+    expect(data.headers.userAgent).toBe('jest')
+  })
+
+  it('GET /api/status handles errors', async () => {
+    const request = createMockNextRequest('http://localhost:3000/api/status')
+    const originalJson = NextResponse.json
+    ;(NextResponse as any).json = () => {
+      throw new Error('Test error')
+    }
+    await expect(GET(request)).rejects.toThrow('Test error')
+    NextResponse.json = originalJson
+  })
+
+  it('HEAD /api/status returns 200', async () => {
+    const res = await HEAD()
+    expect(res.status).toBe(200)
+  })
+
+  it('HEAD /api/status handles errors', async () => {
+    const originalJson = NextResponse.json
+    ;(NextResponse as any).json = () => {
+      throw new Error('Test error')
+    }
+    await expect(HEAD()).rejects.toThrow('Test error')
+    NextResponse.json = originalJson
+  })
+})

--- a/__tests__/integration/api/version.test.ts
+++ b/__tests__/integration/api/version.test.ts
@@ -1,0 +1,21 @@
+import { GET } from '@/app/api/version/route'
+import { NextResponse } from 'next/server'
+import { APP_VERSION } from '@/lib/version'
+
+describe('Version API', () => {
+  it('GET /api/version returns app version', async () => {
+    const res = await GET()
+    expect(res.status).toBe(200)
+    const data = await res.json()
+    expect(data.version).toBe(APP_VERSION)
+  })
+
+  it('GET /api/version handles errors', async () => {
+    const originalJson = NextResponse.json
+    ;(NextResponse as any).json = () => {
+      throw new Error('Test error')
+    }
+    await expect(GET()).rejects.toThrow('Test error')
+    NextResponse.json = originalJson
+  })
+})


### PR DESCRIPTION
## Summary
- add integration tests for health, status, and version endpoints
- add integration tests for plant-beds endpoint with mocked Supabase

## Testing
- `npm test __tests__/integration/api/health.test.ts __tests__/integration/api/status.test.ts __tests__/integration/api/version.test.ts __tests__/integration/api/plant-beds.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68a019a7a3008326a986a6b567ef396d