### PR TITLE
chore(ci): capture jest logs and retry via agent

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -97,19 +97,28 @@ jobs:
         continue-on-error: false
 
       - name: 🧪 Jest - Unit & Integration Tests (CRITICAL)
+        id: unit-tests
+        run: npm run test:ci 2>&1 | tee test-log.txt
+        env:
+          CI: true
+        continue-on-error: true
+
+      - name: 🤖 Agent-assisted Test Retries
+        if: steps.unit-tests.outcome == 'failure'
         run: |
           set -e
           attempts=0
           max_attempts=3
-          until npm run test:ci 2>&1 | tee test-log.txt; do
-            attempts=$((attempts+1))
-            if [ $attempts -ge $max_attempts ]; then
-              echo "Tests failed after $attempts attempts"
-              exit 1
-            fi
+          while [ $attempts -lt $max_attempts ]; do
             echo "📨 Sending logs to agent for patch..."
             bash scripts/agent-fix-tests.sh || true
+            if npm run test:ci 2>&1 | tee test-log.txt; then
+              exit 0
+            fi
+            attempts=$((attempts+1))
           done
+          echo "Tests failed after $max_attempts attempts"
+          exit 1
         env:
           CI: true
         continue-on-error: false


### PR DESCRIPTION
## Summary
- capture Jest test output to `test-log.txt`
- let agent analyze failed tests and retry up to 3 times

## Testing
- `npm test 2>&1 | tail -n 20` *(fails: Cannot find module '../../../lib/config')*

------
https://chatgpt.com/codex/tasks/task_e_68a01b5fe9708326a384c93088c6df6f