### PR TITLE
Add CodeQL scanning workflow for JS/TS

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,30 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main, develop]
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: javascript
+      - name: Analyze
+        uses: github/codeql-action/analyze@v3
+        with:
+          output: results
+      - name: Upload SARIF
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results/codeql.sarif

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Ons systeem gebruikt een **preview-first** aanpak:
 - ✅ **Feature branches** voor alle wijzigingen
 - ✅ **Automatische testing** op elke push
 - ✅ **Quality gates** voor deployment
-- ✅ **Security scanning** geïntegreerd
+- ✅ **Security scanning** geïntegreerd (GitHub CodeQL)
 - ✅ **Coverage monitoring** (minimum 60%)
 
 ### Pipeline Stappen:


### PR DESCRIPTION
## Summary
- add CodeQL analysis workflow for JavaScript/TypeScript
- document CodeQL static analysis in README

## Testing
- `npm run test:ci`
- `npm run ci:quality` *(fails: TS2554 Expected 1-2 arguments)*

------
https://chatgpt.com/codex/tasks/task_e_68a01e0268988326aba9160f0c327715