### PR TITLE
feat: add auto test loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,10 @@ Gebruik deze tools alleen wanneer nodig en voer altijd de verplichte tests uit n
 - [`docs/CI-CD-WORKFLOW.md`](docs/CI-CD-WORKFLOW.md) - CI/CD details
 - [`docs/SECURITY.md`](docs/SECURITY.md) - Security guidelines
 
+## Deployment
+
+Gebruik `scripts/auto-test-loops.js` om `npm run test:ci` automatisch te herhalen tot de tests slagen of het maximale aantal pogingen is bereikt. Bij falen wordt de fout naar `test-log.txt` geschreven en wordt `scripts/agent-fix-tests.sh` uitgevoerd voordat een nieuwe poging start.
+
 ## ⚠️ Belangrijke Regels
 
 ### ❌ NOOIT DOEN:

--- a/scripts/auto-test-loops.js
+++ b/scripts/auto-test-loops.js
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+'use strict';
+
+const { exec, execSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+const MAX_ATTEMPTS = 5;
+const logFile = path.resolve(__dirname, '..', 'test-log.txt');
+
+async function runCommand(cmd) {
+  return new Promise((resolve) => {
+    exec(cmd, { maxBuffer: 1024 * 1024 * 10 }, (error, stdout, stderr) => {
+      process.stdout.write(stdout);
+      if (error) {
+        fs.appendFileSync(logFile, `Attempt failed:\n${stderr}\n`);
+        resolve(false);
+      } else {
+        resolve(true);
+      }
+    });
+  });
+}
+
+(async () => {
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+    console.log(`\nAttempt ${attempt}/${MAX_ATTEMPTS}: running tests...`);
+    const success = await runCommand('npm run test:ci');
+    if (success) {
+      console.log('Tests passed.');
+      process.exit(0);
+    }
+
+    console.error(`Attempt ${attempt} failed. Log written to test-log.txt`);
+    if (attempt < MAX_ATTEMPTS) {
+      try {
+        execSync('scripts/agent-fix-tests.sh', { stdio: 'inherit' });
+      } catch (err) {
+        console.error('agent-fix-tests.sh encountered an error:', err.message);
+      }
+    }
+  }
+
+  console.error(`Tests failed after ${MAX_ATTEMPTS} attempts.`);
+  process.exit(1);
+})();


### PR DESCRIPTION
## Summary
- add auto-test loop script that retries `npm run test:ci` until success or limit
- document auto-test loop usage under Deployment

## Testing
- `npm run test:ci` *(fails: 1 failed, 13 skipped, 76 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68a01e01405c83268507ae1a1e371db6