### PR TITLE
feat: add automated test loop script

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ npm run test:ci
 npm run ci:quality
 ```
 
+## 🔁 Development flow
+
+Gebruik `npm run auto-test-loop` om automatisch `npm run test:ci` uit te voeren en bij falen `scripts/agent-fix-tests.sh` aan te roepen.
+
 ## 📋 Verplichte Workflow
 
 ### Voor elke wijziging:

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "shared:build": "cd packages/shared && npm install && npm run build",
     "deploy:check": "./scripts/auto-deploy-safety.sh",
     "deploy:test": "node scripts/auto-test-loops.js",
+    "auto-test-loop": "node scripts/auto-test-loop.js",
     "deploy:production": "npm run deploy:check && npm run deploy:test && echo 'Ready for production deployment'",
     "security:foundation": "echo 'Run security-implementation/scripts/01-foundation-security.sql in Supabase'",
     "security:test": "echo 'Run security-implementation/tests/test-01-foundation.sql in Supabase'",

--- a/scripts/auto-test-loop.js
+++ b/scripts/auto-test-loop.js
@@ -1,0 +1,23 @@
+#!/usr/bin/env node
+'use strict';
+
+const { spawnSync } = require('child_process');
+
+function run(command, args) {
+  return spawnSync(command, args, { stdio: 'inherit' }).status;
+}
+
+while (true) {
+  const testStatus = run('npm', ['run', 'test:ci']);
+  if (testStatus === 0) {
+    console.log('✅ Tests passed');
+    process.exit(0);
+  }
+
+  console.log('❌ Tests failed, running agent-fix-tests.sh...');
+  const fixStatus = run('bash', ['scripts/agent-fix-tests.sh']);
+  if (fixStatus !== 0) {
+    console.error('Fix script failed. Exiting.');
+    process.exit(testStatus || 1);
+  }
+}


### PR DESCRIPTION
## Summary
- add `scripts/auto-test-loop.js` to rerun tests after invoking `scripts/agent-fix-tests.sh`
- expose `npm run auto-test-loop`
- document automated development flow in README

## Testing
- `npm run test:ci` *(fails: Gardens API tests exceeded timeout)*

------
https://chatgpt.com/codex/tasks/task_e_68a01f2e2c848326b641ac1ba90fb35f