### PR TITLE
chore: broaden jest coverage

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -18,7 +18,11 @@ const customJestConfig = {
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/$1',
   },
-  collectCoverageFrom: ['lib/security/garden-access.ts'],
+  collectCoverageFrom: [
+    'components/**/*.{ts,tsx}',
+    'lib/**/*.{ts,tsx}',
+    'app/**/*.{ts,tsx}',
+  ],
   coverageThreshold: {
     global: {
       branches: 60,


### PR DESCRIPTION
## Summary
- expand Jest coverage to components, lib, and app directories

## Testing
- `npm run test:coverage` *(fails: integration test timeout and coverage threshold not met)*

------
https://chatgpt.com/codex/tasks/task_e_68a0221a417c8326b8cf905bfcda5efb