### PR TITLE
Documenteer handmatige scripts

### DIFF
--- a/docs/CI-CD-SETUP.md
+++ b/docs/CI-CD-SETUP.md
@@ -72,6 +72,14 @@ if: |
 
 ## 🛠️ Automatische Setup
 
+### 0. Master Setup Script
+
+Gebruik het onderstaande script om de volledige CI/CD-configuratie in één keer uit te voeren. Het script valideert de projectstructuur, controleert afhankelijkheden en draait alle noodzakelijke checks.
+
+```bash
+./scripts/setup-ci-cd.sh
+```
+
 ### 1. Branch Protection Script
 
 ```bash

--- a/docs/MAINTENANCE-SCRIPTS.md
+++ b/docs/MAINTENANCE-SCRIPTS.md
@@ -1,0 +1,22 @@
+# Onderhoudscripts
+
+De map `scripts/` bevat hulpscripts voor handmatige opschoontaken. Ze draaien **niet** automatisch in de pipeline. Gebruik ze alleen wanneer nodig en voer daarna altijd de tests uit.
+
+## Beschikbare scripts
+
+- **`fix-all-syntax-final.sh`** – scant TypeScript-bestanden op `NODE_ENV`-blocks en verwijdert resterende console-statements of dubbele checks.
+- **`fix-double-conditionals.sh`** – verwijdert dubbele `NODE_ENV === "development"`-condities.
+- **`fix-closing-braces.sh`** – controleert op ontbrekende sluitaccolades bij conditionele console-statements.
+- **`fix-console-logging.sh`** – maakt console-statements afhankelijk van `NODE_ENV`.
+- **`remove-console.sh`** – verwijdert console-statements uit `lib/database.ts`.
+- **`remove-all-console.sh`** – verwijdert alle console-statements in de codebase.
+
+## Gebruik
+
+Voer een script uit vanuit de projectroot:
+
+```bash
+./scripts/fix-all-syntax-final.sh
+```
+
+Vervang de bestandsnaam door het gewenste script. Voer na afloop altijd `npm test` uit.


### PR DESCRIPTION
## Summary
- Leg hulpscripts uit in nieuwe documentatie `MAINTENANCE-SCRIPTS.md`
- Voeg master setup script toe aan CI/CD documentatie

## Testing
- `npm test` *(fout: timeout in __tests__/integration/api/gardens.test.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68a0221b7cb88326b8bdfbae0c261dd7