### PR TITLE
chore: install bc in CI workflow

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -85,6 +85,9 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
 
+      - name: Install bc
+        run: sudo apt-get update && sudo apt-get install -y bc
+
       - name: Install dependencies
         run: npm ci
 


### PR DESCRIPTION
## Summary
- install `bc` in CI quality job before installing dependencies

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*
- `npm install` *(fails: 403 Forbidden for husky)*

------
https://chatgpt.com/codex/tasks/task_e_68a025f109048326ac9a001596b4fa4c