### PR TITLE
Refactor flower visualization into subcomponents with tests

### DIFF
--- a/__tests__/unit/components/flower-visualization.test.tsx
+++ b/__tests__/unit/components/flower-visualization.test.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import { FlowerVisualization } from '@/components/flower-visualization';
+
+describe('FlowerVisualization', () => {
+  const plantBed = { id: 'bed1', size: '100x100' } as any;
+
+  it('renders nothing when no plants are provided', () => {
+    const { container } = render(
+      <FlowerVisualization
+        plantBed={plantBed}
+        plants={[]}
+        containerWidth={100}
+        containerHeight={100}
+      />
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders a flower at the custom position', () => {
+    const plants = [
+      {
+        id: 'p1',
+        name: 'Rose',
+        color: '#FF0000',
+        position_x: 50,
+        position_y: 60,
+      },
+    ] as any;
+
+    render(
+      <FlowerVisualization
+        plantBed={plantBed}
+        plants={plants}
+        containerWidth={100}
+        containerHeight={100}
+      />
+    );
+
+    const flower = screen.getByTestId('flower-instance');
+    expect(flower).toBeInTheDocument();
+    expect(flower).toHaveStyle({ left: '40px', top: '50px', width: '20px', height: '20px' });
+  });
+
+  it('renders flowers in a grid layout when positions are missing', () => {
+    const plants = [
+      { id: 'p1', name: 'A', color: '#111111' },
+      { id: 'p2', name: 'B', color: '#222222' },
+    ] as any;
+
+    render(
+      <FlowerVisualization
+        plantBed={plantBed}
+        plants={plants}
+        containerWidth={100}
+        containerHeight={100}
+      />
+    );
+
+    const flowers = screen.getAllByTestId('flower-instance');
+    expect(flowers).toHaveLength(2);
+    expect(flowers[0]).toHaveStyle({ left: '20px', top: '40px' });
+    expect(flowers[1]).toHaveStyle({ left: '60px', top: '40px' });
+  });
+});
+

--- a/components/flower-visualization.tsx
+++ b/components/flower-visualization.tsx
@@ -3,6 +3,8 @@
 import React, { useState, useEffect } from 'react'
 import type { PlantBedWithPlants, Plant, PlantWithPosition } from "@/lib/supabase"
 import { parsePlantBedDimensions } from "@/lib/scaling-constants"
+import { getPlantEmoji } from "@/lib/get-plant-emoji"
+import { Flower, FlowerInstance } from "./flower"
 
 interface FlowerVisualizationProps {
   plantBed: PlantBedWithPlants
@@ -11,55 +13,8 @@ interface FlowerVisualizationProps {
   containerHeight: number
 }
 
-interface FlowerInstance {
-  id: string
-  name: string
-  color: string
-  emoji?: string
-  size: number
-  x: number
-  y: number
-  opacity: number
-  rotation: number
-  isMainFlower: boolean
-}
-
 export function FlowerVisualization({ plantBed, plants, containerWidth, containerHeight }: FlowerVisualizationProps) {
   const [flowerInstances, setFlowerInstances] = useState<FlowerInstance[]>([])
-
-  // Helper function to get emoji based on plant name
-  const getPlantEmoji = (name?: string, storedEmoji?: string): string => {
-    // If plant already has a stored emoji, use it
-    if (storedEmoji && storedEmoji.trim()) {
-      return storedEmoji
-    }
-    
-    const plantName = (name || '').toLowerCase()
-    
-    // Exacte matches voor eenjarige bloemen
-    if (plantName.includes('zinnia')) return '🌻'
-    if (plantName.includes('marigold') || plantName.includes('tagetes')) return '🌼'
-    if (plantName.includes('impatiens')) return '🌸'
-    if (plantName.includes('ageratum')) return '🌸'
-    if (plantName.includes('salvia')) return '🌺'
-    if (plantName.includes('verbena')) return '🌸'
-    if (plantName.includes('lobelia')) return '🌸'
-    if (plantName.includes('alyssum')) return '🤍'
-    if (plantName.includes('cosmos')) return '🌸'
-    if (plantName.includes('petunia')) return '🌺'
-    if (plantName.includes('begonia')) return '🌸'
-    if (plantName.includes('viooltje') || plantName.includes('viola')) return '🌸'
-    if (plantName.includes('stiefmoedje') || plantName.includes('pansy')) return '🌸'
-    if (plantName.includes('snapdragon') || plantName.includes('leeuwenbek')) return '🌸'
-    if (plantName.includes('zonnebloem') || plantName.includes('sunflower')) return '🌻'
-    if (plantName.includes('calendula') || plantName.includes('goudsbloem')) return '🌼'
-    if (plantName.includes('nicotiana') || plantName.includes('siertabak')) return '🤍'
-    if (plantName.includes('cleome') || plantName.includes('spinnenbloem')) return '🌸'
-    if (plantName.includes('celosia') || plantName.includes('hanekam')) return '🌺'
-    
-    // Default fallback
-    return '🌸'
-  }
 
   // SIMPLE: Generate flower instances with consistent positioning
   useEffect(() => {
@@ -136,68 +91,8 @@ export function FlowerVisualization({ plantBed, plants, containerWidth, containe
 
   return (
     <div className="absolute inset-0 pointer-events-none overflow-hidden">
-      {flowerInstances.map((flower: FlowerInstance, index: number) => (
-        <div
-          key={flower.id}
-          className="absolute transition-all duration-500 ease-in-out"
-          style={{
-            left: flower.x - flower.size / 2,
-            top: flower.y - flower.size / 2,
-            width: flower.size,
-            height: flower.size,
-            opacity: flower.opacity,
-            transform: `rotate(${flower.rotation}deg)`,
-            zIndex: flower.isMainFlower ? 10 : 8,
-          }}
-        >
-          {/* Simple flower box */}
-          <div
-            className="w-full h-full border-2 border-gray-400 rounded-lg bg-white/90 backdrop-blur-sm shadow-md flex flex-col items-center justify-center"
-            style={{
-              borderColor: `${flower.color}80`,
-              backgroundColor: `${flower.color}25`,
-            }}
-          >
-            {/* Flower emoji */}
-            <span 
-              className="select-none"
-              style={{
-                fontSize: Math.max(12, flower.size * 0.4),
-                filter: 'drop-shadow(0 1px 2px rgba(0,0,0,0.3))',
-              }}
-            >
-              {flower.emoji}
-            </span>
-            
-            {/* Flower name - only show if there's space */}
-            {flower.size > 30 && (
-              <div 
-                className="text-xs font-medium text-gray-800 mt-1 text-center select-none"
-                style={{
-                  fontSize: Math.max(6, flower.size * 0.2),
-                  maxWidth: flower.size * 0.9,
-                  overflow: 'hidden',
-                  textOverflow: 'ellipsis',
-                  whiteSpace: 'nowrap',
-                  lineHeight: '1.1'
-                }}
-              >
-                {flower.name}
-              </div>
-            )}
-          </div>
-
-          {/* Glow effect for main flowers */}
-          {flower.isMainFlower && (
-            <div
-              className="absolute inset-0 rounded-full opacity-20 blur-sm -z-10"
-              style={{
-                backgroundColor: flower.color,
-                transform: 'scale(1.5)',
-              }}
-            />
-          )}
-        </div>
+      {flowerInstances.map((flower) => (
+        <Flower key={flower.id} flower={flower} />
       ))}
 
       {/* Subtle natural particles */}
@@ -223,3 +118,4 @@ export function FlowerVisualization({ plantBed, plants, containerWidth, containe
     </div>
   )
 }
+

--- a/components/flower.tsx
+++ b/components/flower.tsx
@@ -1,0 +1,83 @@
+"use client"
+
+import React from 'react'
+
+export interface FlowerInstance {
+  id: string
+  name: string
+  color: string
+  emoji?: string
+  size: number
+  x: number
+  y: number
+  opacity: number
+  rotation: number
+  isMainFlower: boolean
+}
+
+interface FlowerProps {
+  flower: FlowerInstance
+}
+
+export function Flower({ flower }: FlowerProps) {
+  return (
+    <div
+      data-testid="flower-instance"
+      className="absolute transition-all duration-500 ease-in-out"
+      style={{
+        left: flower.x - flower.size / 2,
+        top: flower.y - flower.size / 2,
+        width: flower.size,
+        height: flower.size,
+        opacity: flower.opacity,
+        transform: `rotate(${flower.rotation}deg)`,
+        zIndex: flower.isMainFlower ? 10 : 8,
+      }}
+    >
+      <div
+        className="w-full h-full border-2 border-gray-400 rounded-lg bg-white/90 backdrop-blur-sm shadow-md flex flex-col items-center justify-center"
+        style={{
+          borderColor: `${flower.color}80`,
+          backgroundColor: `${flower.color}25`,
+        }}
+      >
+        <span
+          className="select-none"
+          style={{
+            fontSize: Math.max(12, flower.size * 0.4),
+            filter: 'drop-shadow(0 1px 2px rgba(0,0,0,0.3))',
+          }}
+        >
+          {flower.emoji}
+        </span>
+
+        {flower.size > 30 && (
+          <div
+            className="text-xs font-medium text-gray-800 mt-1 text-center select-none"
+            style={{
+              fontSize: Math.max(6, flower.size * 0.2),
+              maxWidth: flower.size * 0.9,
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              whiteSpace: 'nowrap',
+              lineHeight: '1.1',
+            }}
+          >
+            {flower.name}
+          </div>
+        )}
+      </div>
+
+      {flower.isMainFlower && (
+        <div
+          className="absolute inset-0 rounded-full opacity-20 blur-sm -z-10"
+          style={{
+            backgroundColor: flower.color,
+            transform: 'scale(1.5)',
+          }}
+        />
+      )}
+    </div>
+  )
+}
+

--- a/lib/get-plant-emoji.ts
+++ b/lib/get-plant-emoji.ts
@@ -1,0 +1,28 @@
+export function getPlantEmoji(name?: string, storedEmoji?: string): string {
+  if (storedEmoji && storedEmoji.trim()) {
+    return storedEmoji;
+  }
+
+  const plantName = (name || '').toLowerCase();
+
+  if (plantName.includes('zinnia')) return '🌻';
+  if (plantName.includes('marigold') || plantName.includes('tagetes')) return '🌼';
+  if (plantName.includes('impatiens')) return '🌸';
+  if (plantName.includes('ageratum')) return '🌸';
+  if (plantName.includes('salvia')) return '🌺';
+  if (plantName.includes('verbena')) return '🌸';
+  if (plantName.includes('lobelia')) return '🌸';
+  if (plantName.includes('alyssum')) return '🤍';
+  if (plantName.includes('cosmos')) return '🌸';
+  if (plantName.includes('petunia')) return '🌺';
+  if (plantName.includes('begonia')) return '🌸';
+  if (plantName.includes('viooltje') || plantName.includes('viola')) return '🌸';
+  if (plantName.includes('stiefmoedje') || plantName.includes('pansy')) return '🌸';
+  if (plantName.includes('snapdragon') || plantName.includes('leeuwenbek')) return '🌸';
+  if (plantName.includes('zonnebloem') || plantName.includes('sunflower')) return '🌻';
+  if (plantName.includes('calendula') || plantName.includes('goudsbloem')) return '🌼';
+  if (plantName.includes('nicotiana') || plantName.includes('siertabak')) return '🤍';
+  if (plantName.includes('cleome') || plantName.includes('spinnenbloem')) return '🌸';
+  if (plantName.includes('celosia') || plantName.includes('hanekam')) return '🌺';
+  return '🌸';
+}


### PR DESCRIPTION
## Summary
- extract `getPlantEmoji` utility and reuse in flower rendering
- move individual flower rendering into new `Flower` subcomponent
- add unit tests for `FlowerVisualization` rendering and layout

## Testing
- `npm test __tests__/unit/components/flower-visualization.test.tsx` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a029d34c0c8326873969d60d66c943