### PR TITLE
chore: increase agent test fix retries

### DIFF
--- a/docs/CI-CD-WORKFLOW.md
+++ b/docs/CI-CD-WORKFLOW.md
@@ -187,6 +187,7 @@ git push origin feature/nieuwe-functie
 2. Fix de issues lokaal
 3. Push opnieuw
 4. Pipeline draait automatisch
+5. Gebruik `scripts/agent-fix-tests.sh` voor automatische patches. Deze probeert nu maximaal **5** keer een fix toe te passen.
 
 ### **Coverage te laag:**
 1. Voeg meer tests toe

--- a/scripts/agent-fix-tests.sh
+++ b/scripts/agent-fix-tests.sh
@@ -5,6 +5,9 @@ set -euo pipefail
 
 API_URL="${AGENT_API_URL:-}"
 
+# Maximum number of attempts to fetch and apply a patch from the agent
+MAX_RETRIES=5
+
 if [[ -z "$API_URL" ]]; then
   echo "AGENT_API_URL not set; skipping agent fix."
   exit 0


### PR DESCRIPTION
## Summary
- raise `MAX_RETRIES` in agent-fix script to 5 attempts
- document new agent retry limit in CI/CD workflow guide

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a02cf432ec8326bc1ef163c81f6696