### PR TITLE
chore(ci): enforce docs update

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -502,6 +502,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: 📝 Ensure documentation updated
+        run: ./scripts/ensure-docs-updated.sh
+
       - name: 📚 Check Documentation Updates
         run: |
           echo "📚 Checking documentation compliance..."

--- a/README.md
+++ b/README.md
@@ -160,6 +160,8 @@ Gebruik deze tools alleen wanneer nodig en voer altijd de verplichte tests uit n
 - [`docs/CI-CD-WORKFLOW.md`](docs/CI-CD-WORKFLOW.md) - CI/CD details
 - [`docs/SECURITY.md`](docs/SECURITY.md) - Security guidelines
 
+> 📝 **Let op:** Bij elke codewijziging moet `README.md` of een bestand in `docs/` worden bijgewerkt. De CI/CD pipeline faalt als er geen documentatie-update is.
+
 ## Deployment
 
 Gebruik `scripts/auto-test-loop.js` om `npm run test:ci` automatisch te herhalen tot de tests slagen of het maximale aantal pogingen is bereikt. Bij falen wordt de fout naar `test-log.txt` geschreven en wordt `scripts/agent-fix-tests.sh` uitgevoerd voordat een nieuwe poging start.
@@ -177,6 +179,7 @@ Gebruik `scripts/auto-test-loop.js` om `npm run test:ci` automatisch te herhalen
 - CI/CD pipeline na elke wijziging
 - Continue loop tot succes
 - Feature branch gebruiken
+- Documentatie bijwerken wanneer code verandert (README.md of `docs/`)
 
 ## 🤝 Bijdragen
 

--- a/docs/CI-CD-WORKFLOW.md
+++ b/docs/CI-CD-WORKFLOW.md
@@ -60,6 +60,10 @@ git push origin feature/nieuwe-functie
 - Main → Production deployment
 - Geen uitzonderingen mogelijk
 
+### **📝 Documentatie bijwerken**
+- Bij elke codewijziging moet `README.md` of een bestand in `docs/` worden geüpdatet
+- De pipeline controleert dit en faalt bij ontbrekende documentatie
+
 ### **🔒 Banking-Grade Security**
 - 60% minimum code coverage (→ 80% in 2 weken)
 - Alle security checks moeten slagen

--- a/scripts/ensure-docs-updated.sh
+++ b/scripts/ensure-docs-updated.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_BRANCH="${GITHUB_BASE_REF:-main}"
+git fetch origin "$BASE_BRANCH" >/dev/null 2>&1 || true
+
+if git rev-parse --verify "origin/$BASE_BRANCH" >/dev/null 2>&1; then
+  COMPARE_BRANCH="origin/$BASE_BRANCH"
+else
+  COMPARE_BRANCH="$BASE_BRANCH"
+fi
+
+DIFF_FILES=$(git diff --name-only "$COMPARE_BRANCH"...HEAD)
+
+CODE_CHANGES=$(echo "$DIFF_FILES" | grep -Ev '^(docs/|README.md$)' || true)
+DOC_CHANGES=$(echo "$DIFF_FILES" | grep -E '^(docs/|README.md$)' || true)
+
+if [[ -n "$CODE_CHANGES" && -z "$DOC_CHANGES" ]]; then
+  echo "❌ Documentation missing: update README.md or docs/ when modifying code."
+  echo "Code changes detected:"
+  echo "$CODE_CHANGES"
+  exit 1
+fi
+
+echo "✅ Documentation is up to date."


### PR DESCRIPTION
## Summary
- check docs and README updates when code changes
- run documentation check in CI
- document doc-update requirement for contributors

## Testing
- `./scripts/ensure-docs-updated.sh`
- `npm ci` (fails: package-lock mismatch)
- `npm test` (fails: jest not found)


------
https://chatgpt.com/codex/tasks/task_e_68a02cf5671083268ccd1d8f1e0850ca