### PR TITLE
chore: raise coverage threshold to 80%

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -18,7 +18,7 @@ on:
 
 env:
   NODE_VERSION: '18'
-  COVERAGE_THRESHOLD: '60'  # Start with 60%, increase to 80% in 2 weeks
+  COVERAGE_THRESHOLD: '80'  # Minimum required coverage
 
 jobs:
   # 🔍 CHANGE DETECTION
@@ -126,7 +126,7 @@ jobs:
           CI: true
         continue-on-error: false
 
-        - name: 📊 Coverage Threshold Validation (CRITICAL - 60% MINIMUM)
+      - name: 📊 Coverage Threshold Validation (CRITICAL - 80% MINIMUM)
           run: |
             echo "🔍 Validating test coverage thresholds..."
             echo "🎯 Target: ${{ env.COVERAGE_THRESHOLD }}% minimum coverage"
@@ -555,14 +555,14 @@ jobs:
              [ "${{ needs.docs.result }}" == "success" ]; then
             echo "✅ ALL QUALITY GATES PASSED - Ready for deployment!"
             echo "🚀 Preview deployment will be triggered automatically"
-            echo "📊 Coverage target: ${{ env.COVERAGE_THRESHOLD }}% (Phase 1: 60% → 80% in 2 weeks)"
+          echo "📊 Coverage target: ${{ env.COVERAGE_THRESHOLD }}%"
           else
             echo "❌ QUALITY GATES FAILED - Deployment blocked!"
             echo "🔒 Preview deployment will NOT be triggered"
             echo "📋 Please fix the following issues:"
             
             if [ "${{ needs.quality.result }}" != "success" ]; then
-              echo "  - Quality Gates (Lint, Types, Tests, 60% Coverage)"
+              echo "  - Quality Gates (Lint, Types, Tests, 80% Coverage)"
             fi
             if [ "${{ needs.security.result }}" != "success" ]; then
               echo "  - Security & Compliance (SAST, Secrets Detection)"
@@ -590,7 +590,7 @@ jobs:
           echo "📋 Please fix all issues and push again"
           echo ""
           echo "🎯 Current Requirements:"
-          echo "  - 60% minimum code coverage"
+          echo "  - 80% minimum code coverage"
           echo "  - All security checks must pass"
           echo "  - All regression tests must pass"
           echo "  - Build must succeed"

--- a/README.md
+++ b/README.md
@@ -8,14 +8,14 @@ Een professioneel tuinbeheer systeem gebouwd met Next.js, Supabase en TailwindCS
 
 1. **LOCALE TESTING** vóór elke wijziging: `npm run test:ci`
 2. **CI/CD PIPELINE** na elke wijziging: `npm run ci:quality`
-3. **CONTINUE LOOP** tot alle tests slagen en coverage ≥60% is
+3. **CONTINUE LOOP** tot alle tests slagen en coverage ≥80% is
 4. **ALLEEN DAN** naar feature branch pushen
 
 📖 **Lees de volledige workflow**: [`docs/STANDARD-WORKFLOW.md`](docs/STANDARD-WORKFLOW.md)
 
 ## 🎯 Huidige Status
 
-- **Test Coverage**: 3.38% (doel: 60%)
+- **Test Coverage**: 3.38% (doel: 80%)
 - **Tests**: 154 passed, 31 skipped
 - **CI/CD Pipeline**: In ontwikkeling
 - **Kwaliteit**: Banking-grade standaard
@@ -54,7 +54,7 @@ npm run ci:quality       # CI/CD pipeline
 
 ### Continue loop tot succes:
 - Herhaal tot alle tests slagen
-- Herhaal tot coverage ≥60% is
+- Herhaal tot coverage ≥80% is
 - Herhaal tot pipeline groen is
 
 ## 🪝 Git hook voor push
@@ -100,7 +100,7 @@ Ons systeem gebruikt een **preview-first** aanpak:
 - ✅ **Automatische testing** op elke push
 - ✅ **Quality gates** voor deployment
 - ✅ **Security scanning** geïntegreerd (GitHub CodeQL)
-- ✅ **Coverage monitoring** (minimum 60%)
+- ✅ **Coverage monitoring** (minimum 80%)
 
 ### Pipeline Stappen:
 1. **Quality Check**: Lint, TypeScript, Tests
@@ -138,8 +138,7 @@ Gebruik deze tools alleen wanneer nodig en voer altijd de verplichte tests uit n
 
 ### Coverage Doelen:
 - **Huidig**: 3.38%
-- **Week 1**: 60% (minimum)
-- **Week 2**: 80% (doel)
+- **Minimum**: 80%
 
 ### Test Types:
 - **Unit Tests**: Individuele functies
@@ -199,7 +198,7 @@ Gebruik `scripts/auto-test-loop.js` om `npm run test:ci` automatisch te herhalen
 
 **EINDOEL**: Volledig groene CI/CD pipeline met:
 - ✅ 100% test success rate
-- ✅ ≥60% code coverage
+- ✅ ≥80% code coverage
 - ✅ Banking-grade kwaliteit
 - ✅ Automatische security scanning
 

--- a/docs/CI-CD-WORKFLOW.md
+++ b/docs/CI-CD-WORKFLOW.md
@@ -36,7 +36,7 @@ git push origin feature/nieuwe-functie
 ```
 
 ### **4. Automatische CI/CD Pipeline**
-✅ **Quality Gates** (ESLint, TypeScript, Tests, 60% Coverage)  
+✅ **Quality Gates** (ESLint, TypeScript, Tests, 80% Coverage)
 ✅ **Security Checks** (SAST, Secrets Detection, Vulnerability Scan)  
 ✅ **Regression Tests** (E2E, API Integration, Database, Auth)  
 ✅ **Build Validation** (Next.js build, Post-build tests)  
@@ -61,7 +61,7 @@ git push origin feature/nieuwe-functie
 - Geen uitzonderingen mogelijk
 
 ### **🔒 Banking-Grade Security**
-- 60% minimum code coverage (→ 80% in 2 weken)
+- 80% minimum code coverage
 - Alle security checks moeten slagen
 - Geen hardcoded secrets
 - SAST en dependency scanning
@@ -95,7 +95,7 @@ git push origin feature/nieuwe-functie
 ### **Quality Gates:**
 - **ESLint**: Code kwaliteit
 - **TypeScript**: Type safety
-- **Jest Tests**: Unit tests met 60% coverage
+- **Jest Tests**: Unit tests met 80% coverage
 - **Security Audit**: Vulnerabilities
 
 ### **Security Checks:**
@@ -119,13 +119,6 @@ git push origin feature/nieuwe-functie
 
 ## 📊 **Code Coverage Requirements**
 
-### **Phase 1 (Nu): 60% Minimum**
-- Branches: 60%
-- Functions: 60%
-- Lines: 60%
-- Statements: 60%
-
-### **Phase 2 (Over 2 weken): 80% Minimum**
 - Branches: 80%
 - Functions: 80%
 - Lines: 80%
@@ -192,7 +185,7 @@ git push origin feature/nieuwe-functie
 1. Voeg meer tests toe
 2. Check coverage report
 3. Focus op ongedekte code
-4. Herhaal tot 60% bereikt
+4. Herhaal tot 80% bereikt
 
 ### **Security issues:**
 1. Fix hardcoded secrets
@@ -220,7 +213,7 @@ git push origin feature/nieuwe-functie
 ## 🔮 **Toekomstige Uitbreidingen**
 
 ### **Phase 2 (Over 2 weken):**
-- Code coverage naar 80%
+- Code coverage naar 90%
 - Uitgebreide E2E tests
 - Performance testing
 - Load testing
@@ -237,4 +230,4 @@ git push origin feature/nieuwe-functie
 
 **🔒 Security First: Alle security checks moeten slagen voor deployment!**
 
-**📊 Coverage: Start met 60%, ga naar 80% in 2 weken!**
+**📊 Coverage: minimaal 80%!**

--- a/jest.config.js
+++ b/jest.config.js
@@ -25,10 +25,10 @@ const customJestConfig = {
   ],
   coverageThreshold: {
     global: {
-      branches: 60,
-      functions: 60,
-      lines: 60,
-      statements: 60,
+      branches: 80,
+      functions: 80,
+      lines: 80,
+      statements: 80,
     },
   },
 }


### PR DESCRIPTION
## Summary
- enforce 80% coverage in CI pipeline
- require 80% coverage in Jest configuration
- document new 80% coverage standard in README and CI/CD workflow docs

## Testing
- `npm run test:ci` *(fails: jest not found; dependency installation blocked by 403 from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68a02cf989088326af5c649bdea926dd