### PR TITLE
Require signed commits and document commit signing

### DIFF
--- a/.github/branch-protection.yml
+++ b/.github/branch-protection.yml
@@ -17,7 +17,8 @@ main:
     dismiss_stale_reviews: true
     require_code_owner_reviews: true
     require_last_push_approval: true
-  
+  required_signatures: true
+
   enforce_admins: true
   allow_force_pushes: false
   allow_deletions: false
@@ -42,7 +43,8 @@ develop:
     dismiss_stale_reviews: true
     require_code_owner_reviews: false
     require_last_push_approval: true
-  
+  required_signatures: true
+
   enforce_admins: false
   allow_force_pushes: false
   allow_deletions: false

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,4 +1,15 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
+unsigned_commits=$(git rev-list --not --remotes | while read commit; do
+  [ "$(git log -1 --pretty=%G? "$commit")" = "G" ] || echo "$commit"
+done)
+
+if [ -n "$unsigned_commits" ]; then
+  echo "🚫 unsigned commits detected:"
+  echo "$unsigned_commits"
+  echo "Please sign your commits (git commit -S) before pushing."
+  exit 1
+fi
+
 npm run test:ci || exit 1

--- a/README.md
+++ b/README.md
@@ -72,6 +72,13 @@ git push --no-verify
 HUSKY=0 git push
 ```
 
+## 🔏 How to sign commits
+
+1. Generate a GPG key: `gpg --full-generate-key`
+2. List your keys: `gpg --list-secret-keys --keyid-format=long`
+3. Configure Git to use the key: `git config --global user.signingkey <KEY_ID>`
+4. Enable automatic signing: `git config --global commit.gpgsign true`
+
 ## 🔧 Beschikbare Scripts
 
 ```bash


### PR DESCRIPTION
## Summary
- enforce signed commits for main and develop in branch protection rules
- document how to sign commits in README
- block unsigned commits via Husky pre-push hook

## Testing
- `npm run test:ci` *(fails: jest not found)*
- `npm install --no-audit --no-fund` *(fails: 403 Forbidden to registry)*

------
https://chatgpt.com/codex/tasks/task_e_68a02cf72c7c8326af70dc2abbe4c26d