### PR TITLE
Add Gitleaks secret scanning workflow

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,16 @@
+name: Secret Scan
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  gitleaks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Run Gitleaks
+        uses: gitleaks/gitleaks-action@v1
+        with:
+          args: --no-banner --redact

--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ Gebruik deze tools alleen wanneer nodig en voer altijd de verplichte tests uit n
 - **Authentication**: Supabase Auth integratie
 - **Audit Logging**: Alle acties gelogd
 - **Security Scanning**: Automatische vulnerability detectie
+- **Secret Scanning**: Gitleaks controleert elke `push` en `pull_request` op hardcoded secrets (zie [CI/CD workflow](docs/CI-CD-WORKFLOW.md))
 
 ## 📚 Documentatie
 

--- a/docs/CI-CD-WORKFLOW.md
+++ b/docs/CI-CD-WORKFLOW.md
@@ -133,6 +133,10 @@ git push origin feature/nieuwe-functie
 
 ## 🔒 **Security Testing**
 
+### **Secrets Scan (Gitleaks):**
+- Workflow `.github/workflows/secret-scan.yml` draait [Gitleaks](https://github.com/gitleaks/gitleaks) bij elke `push` en `pull_request`.
+- Vindt hardcoded secrets en laat de job falen totdat de secret is verwijderd.
+
 ### **SAST (Static Analysis):**
 - SQL injection patterns
 - XSS vulnerabilities


### PR DESCRIPTION
## Summary
- add Gitleaks-based secret scan for pushes and pull requests
- document secret scan in CI/CD guide and reference in README

## Testing
- `npm run lint` *(fails: sh: 1: next: not found)*
- `npm run test:ci` *(fails: sh: 1: jest: not found)*
- `timeout 100 npm install` *(fails: 403 Forbidden for husky package)*

------
https://chatgpt.com/codex/tasks/task_e_68a02cf63c7c8326a1bf22346e684d38