### PR TITLE
ci: protect main branch with pipeline

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -2,9 +2,9 @@ name: Banking-Grade CI/CD Pipeline
 
 on:
   push:
-    branches: [ 'feature/**', 'bugfix/**', 'hotfix/**', 'preview/**' ]
+    branches: [ 'feature/**', 'bugfix/**', 'hotfix/**', 'preview/**', 'main' ]
   pull_request:
-    branches: [ main, develop ]
+    branches: [ preview, main ]
   workflow_dispatch:
     inputs:
       environment:


### PR DESCRIPTION
## Summary
- run CI on pull requests to preview and main branches
- add main to push triggers so releases run through pipeline

## Testing
- `npm ci` *(fails: Missing husky@9.1.7 from lock file)*
- `npm run test:ci` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a011cd6b80832693ee729d225d7922