### PR TITLE
chore: enforce 80% coverage threshold

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -18,7 +18,7 @@ on:
 
 env:
   NODE_VERSION: '18'
-  COVERAGE_THRESHOLD: '60'  # Start with 60%, increase to 80% in 2 weeks
+  COVERAGE_THRESHOLD: '80'  # Minimum required coverage
 
 jobs:
   # 🔍 CHANGE DETECTION
@@ -126,28 +126,28 @@ jobs:
           CI: true
         continue-on-error: false
 
-        - name: 📊 Coverage Threshold Validation (CRITICAL - 60% MINIMUM)
-          run: |
-            echo "🔍 Validating test coverage thresholds..."
-            echo "🎯 Target: ${{ env.COVERAGE_THRESHOLD }}% minimum coverage"
+      - name: 📊 Coverage Threshold Validation (CRITICAL - 80% MINIMUM)
+        run: |
+          echo "🔍 Validating test coverage thresholds..."
+          echo "🎯 Target: ${{ env.COVERAGE_THRESHOLD }}% minimum coverage"
 
-            if [ ! -f "coverage/lcov.info" ]; then
-              echo "❌ CRITICAL: No coverage report generated - tests failed!"
-              exit 1
-            fi
+          if [ ! -f "coverage/lcov.info" ]; then
+            echo "❌ CRITICAL: No coverage report generated - tests failed!"
+            exit 1
+          fi
 
-            # Calculate line coverage percentage from lcov.info
-            COVERAGE=$(awk -F: '/^LH:/ {lh+=$2} /^LF:/ {lf+=$2} END {if (lf>0) printf "%.2f", (lh/lf)*100}' coverage/lcov.info)
-            echo "📈 Line coverage: ${COVERAGE}%"
+          # Calculate line coverage percentage from lcov.info
+          COVERAGE=$(awk -F: '/^LH:/ {lh+=$2} /^LF:/ {lf+=$2} END {if (lf>0) printf "%.2f", (lh/lf)*100}' coverage/lcov.info)
+          echo "📈 Line coverage: ${COVERAGE}%"
 
-            # Compare against threshold using bc for precision
-            if [ "$(echo "$COVERAGE < ${COVERAGE_THRESHOLD}" | bc -l)" -eq 1 ]; then
-              echo "❌ Coverage ${COVERAGE}% is below required ${COVERAGE_THRESHOLD}%"
-              exit 1
-            fi
+          # Compare against threshold using bc for precision
+          if [ "$(echo "$COVERAGE < ${COVERAGE_THRESHOLD}" | bc -l)" -eq 1 ]; then
+            echo "❌ Coverage ${COVERAGE}% is below required ${COVERAGE_THRESHOLD}%"
+            exit 1
+          fi
 
-            echo "✅ Coverage threshold met."
-            echo "✅ All quality gates passed successfully!"
+          echo "✅ Coverage threshold met."
+          echo "✅ All quality gates passed successfully!"
 
       - name: 📊 Upload Coverage to Codecov
         uses: codecov/codecov-action@v4
@@ -590,14 +590,14 @@ jobs:
              [ "${{ needs.docs.result }}" == "success" ]; then
             echo "✅ ALL QUALITY GATES PASSED - Ready for deployment!"
             echo "🚀 Preview deployment will be triggered automatically"
-            echo "📊 Coverage target: ${{ env.COVERAGE_THRESHOLD }}% (Phase 1: 60% → 80% in 2 weeks)"
+            echo "📊 Coverage target: ${{ env.COVERAGE_THRESHOLD }}%"
           else
             echo "❌ QUALITY GATES FAILED - Deployment blocked!"
             echo "🔒 Preview deployment will NOT be triggered"
             echo "📋 Please fix the following issues:"
             
             if [ "${{ needs.quality.result }}" != "success" ]; then
-              echo "  - Quality Gates (Lint, Types, Tests, 60% Coverage)"
+              echo "  - Quality Gates (Lint, Types, Tests, 80% Coverage)"
             fi
             if [ "${{ needs.security.result }}" != "success" ]; then
               echo "  - Security & Compliance (SAST, Secrets Detection)"
@@ -628,7 +628,7 @@ jobs:
           echo "📋 Please fix all issues and push again"
           echo ""
           echo "🎯 Current Requirements:"
-          echo "  - 60% minimum code coverage"
+          echo "  - 80% minimum code coverage"
           echo "  - All security checks (SAST & DAST) must pass"
           echo "  - All regression tests must pass"
           echo "  - Build must succeed"

--- a/README.md
+++ b/README.md
@@ -8,14 +8,14 @@ Een professioneel tuinbeheer systeem gebouwd met Next.js, Supabase en TailwindCS
 
 1. **LOCALE TESTING** vóór elke wijziging: `npm run test:ci`
 2. **CI/CD PIPELINE** na elke wijziging: `npm run ci:quality`
-3. **CONTINUE LOOP** tot alle tests slagen en coverage ≥60% is
+3. **CONTINUE LOOP** tot alle tests slagen en coverage ≥80% is
 4. **ALLEEN DAN** naar feature branch pushen
 
 📖 **Lees de volledige workflow**: [`docs/STANDARD-WORKFLOW.md`](docs/STANDARD-WORKFLOW.md)
 
 ## 🎯 Huidige Status
 
-- **Test Coverage**: 3.38% (doel: 60%)
+- **Test Coverage**: 3.38% (doel: 80%)
 - **Tests**: 154 passed, 31 skipped
 - **CI/CD Pipeline**: In ontwikkeling
 - **Kwaliteit**: Banking-grade standaard
@@ -54,7 +54,7 @@ npm run ci:quality       # CI/CD pipeline
 
 ### Continue loop tot succes:
 - Herhaal tot alle tests slagen
-- Herhaal tot coverage ≥60% is
+- Herhaal tot coverage ≥80% is
 - Herhaal tot pipeline groen is
 
 ## 🪝 Git hook voor push
@@ -107,7 +107,7 @@ Ons systeem gebruikt een **preview-first** aanpak:
 - ✅ **Automatische testing** op elke push
 - ✅ **Quality gates** voor deployment
 - ✅ **Security scanning** geïntegreerd (GitHub CodeQL)
-- ✅ **Coverage monitoring** (minimum 60%)
+- ✅ **Coverage monitoring** (minimum 80%)
 
 ### Pipeline Stappen:
 1. **Quality Check**: Lint, TypeScript, Tests
@@ -145,8 +145,7 @@ Gebruik deze tools alleen wanneer nodig en voer altijd de verplichte tests uit n
 
 ### Coverage Doelen:
 - **Huidig**: 3.38%
-- **Week 1**: 60% (minimum)
-- **Week 2**: 80% (doel)
+- **Minimum**: 80%
 
 ### Test Types:
 - **Unit Tests**: Individuele functies
@@ -210,7 +209,7 @@ Gebruik `scripts/auto-test-loop.js` om `npm run test:ci` automatisch te herhalen
 
 **EINDOEL**: Volledig groene CI/CD pipeline met:
 - ✅ 100% test success rate
-- ✅ ≥60% code coverage
+- ✅ ≥80% code coverage
 - ✅ Banking-grade kwaliteit
 - ✅ Automatische security scanning
 

--- a/docs/CI-CD-WORKFLOW.md
+++ b/docs/CI-CD-WORKFLOW.md
@@ -36,7 +36,7 @@ git push origin feature/nieuwe-functie
 ```
 
 ### **4. Automatische CI/CD Pipeline**
-✅ **Quality Gates** (ESLint, TypeScript, Tests, 60% Coverage)  
+✅ **Quality Gates** (ESLint, TypeScript, Tests, 80% Coverage)
 ✅ **Security Checks** (SAST, Secrets Detection, Vulnerability Scan)  
 ✅ **Regression Tests** (E2E, API Integration, Database, Auth)  
 ✅ **Build Validation** (Next.js build, Post-build tests)  
@@ -65,7 +65,7 @@ git push origin feature/nieuwe-functie
 - De pipeline controleert dit en faalt bij ontbrekende documentatie
 
 ### **🔒 Banking-Grade Security**
-- 60% minimum code coverage (→ 80% in 2 weken)
+- 80% minimum code coverage
 - Alle security checks moeten slagen
 - Geen hardcoded secrets
 - SAST en dependency scanning
@@ -99,7 +99,7 @@ git push origin feature/nieuwe-functie
 ### **Quality Gates:**
 - **ESLint**: Code kwaliteit
 - **TypeScript**: Type safety
-- **Jest Tests**: Unit tests met 60% coverage
+- **Jest Tests**: Unit tests met 80% coverage
 - **Security Audit**: Vulnerabilities
 
 ### **Security Checks:**
@@ -123,13 +123,6 @@ git push origin feature/nieuwe-functie
 
 ## 📊 **Code Coverage Requirements**
 
-### **Phase 1 (Nu): 60% Minimum**
-- Branches: 60%
-- Functions: 60%
-- Lines: 60%
-- Statements: 60%
-
-### **Phase 2 (Over 2 weken): 80% Minimum**
 - Branches: 80%
 - Functions: 80%
 - Lines: 80%
@@ -201,7 +194,7 @@ git push origin feature/nieuwe-functie
 1. Voeg meer tests toe
 2. Check coverage report
 3. Focus op ongedekte code
-4. Herhaal tot 60% bereikt
+4. Herhaal tot 80% bereikt
 
 ### **Security issues:**
 1. Fix hardcoded secrets
@@ -229,7 +222,7 @@ git push origin feature/nieuwe-functie
 ## 🔮 **Toekomstige Uitbreidingen**
 
 ### **Phase 2 (Over 2 weken):**
-- Code coverage naar 80%
+- Code coverage naar 90%
 - Uitgebreide E2E tests
 - Performance testing
 - Load testing
@@ -246,4 +239,4 @@ git push origin feature/nieuwe-functie
 
 **🔒 Security First: Alle security checks moeten slagen voor deployment!**
 
-**📊 Coverage: Start met 60%, ga naar 80% in 2 weken!**
+**📊 Coverage: minimaal 80%!**

--- a/jest.config.js
+++ b/jest.config.js
@@ -25,10 +25,10 @@ const customJestConfig = {
   ],
   coverageThreshold: {
     global: {
-      branches: 60,
-      functions: 60,
-      lines: 60,
-      statements: 60,
+      branches: 80,
+      functions: 80,
+      lines: 80,
+      statements: 80,
     },
   },
 }


### PR DESCRIPTION
## Summary
- require 80% coverage in CI workflow and quality gate messaging
- document 80% minimum in README and CI/CD workflow guide
- configure Jest to enforce 80% coverage for branches, functions, lines and statements

## Testing
- `npm install --no-progress` *(fails: 403 Forbidden - GET https://registry.npmjs.org/husky)*
- `npm run test:ci` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0b31b05ac83268d8d09d16188006a