### PR TITLE
Replace bloem with plant

### DIFF
--- a/__tests__/unit/lib/dutch-flowers.test.ts
+++ b/__tests__/unit/lib/dutch-flowers.test.ts
@@ -56,7 +56,7 @@ describe('Dutch Flowers', () => {
   describe('Constants', () => {
     it('should have correct flower categories', () => {
       expect(FLOWER_CATEGORIES).toEqual({
-        'eenjarig': 'Eenjarige bloemen',
+        'eenjarig': 'Eenjarige planten',
         'vaste_planten': 'Vaste planten',
         'bolgewassen': 'Bolgewassen',
         'struiken': 'Struiken',

--- a/__tests__/unit/lib/types/index.test.ts
+++ b/__tests__/unit/lib/types/index.test.ts
@@ -1,11 +1,11 @@
 import {
   Tuin,
   Plantvak,
-  Bloem,
+  Plant,
   LogbookEntry,
   TuinFormData,
   PlantvakFormData,
-  BloemFormData,
+  PlantFormData,
   Position,
   Size,
   Bounds,
@@ -85,8 +85,8 @@ describe('Types Index', () => {
       expect(mockPlantvak.sun_exposure).toBe('full-sun');
     });
 
-    it('should have correct Bloem interface structure', () => {
-      const mockBloem: Bloem = {
+    it('should have correct Plant interface structure', () => {
+      const mockPlant: Plant = {
         id: 'plant-1',
         plant_bed_id: 'bed-1',
         name: 'Test Plant',
@@ -120,10 +120,10 @@ describe('Types Index', () => {
         updated_at: '2024-01-01T00:00:00Z'
       };
 
-      expect(mockBloem.id).toBe('plant-1');
-      expect(mockBloem.plant_bed_id).toBe('bed-1');
-      expect(mockBloem.status).toBe('gezond');
-      expect(mockBloem.sun_preference).toBe('full-sun');
+      expect(mockPlant.id).toBe('plant-1');
+      expect(mockPlant.plant_bed_id).toBe('bed-1');
+      expect(mockPlant.status).toBe('gezond');
+      expect(mockPlant.sun_preference).toBe('full-sun');
     });
   });
 
@@ -164,8 +164,8 @@ describe('Types Index', () => {
       expect(mockPlantvakFormData.description).toBe('A new plant bed for vegetables');
     });
 
-    it('should have correct BloemFormData interface structure', () => {
-      const mockBloemFormData: BloemFormData = {
+    it('should have correct PlantFormData interface structure', () => {
+      const mockPlantFormData: PlantFormData = {
         name: 'New Plant',
         latin_name: 'Novus plantus',
         scientific_name: 'Novus plantus',
@@ -185,9 +185,9 @@ describe('Types Index', () => {
         fertilizer_schedule: 'Bi-weekly'
       };
 
-      expect(mockBloemFormData.name).toBe('New Plant');
-      expect(mockBloemFormData.status).toBe('aandacht_nodig');
-      expect(mockBloemFormData.sun_preference).toBe('shade');
+      expect(mockPlantFormData.name).toBe('New Plant');
+      expect(mockPlantFormData.status).toBe('aandacht_nodig');
+      expect(mockPlantFormData.sun_preference).toBe('shade');
     });
   });
 

--- a/__tests__/unit/lib/validation/index.test.ts
+++ b/__tests__/unit/lib/validation/index.test.ts
@@ -1,7 +1,7 @@
 import {
   validateTuinFormData,
   validatePlantvakFormData,
-  validateBloemFormData,
+  validatePlantFormData,
   validateEmail,
   validatePhoneNumber,
   validateDate,
@@ -200,7 +200,7 @@ describe('Validation Functions', () => {
     })
   })
 
-  describe('validateBloemFormData', () => {
+  describe('validatePlantFormData', () => {
     it('should validate valid plant data', () => {
       const validData = {
         name: 'Rose',
@@ -217,7 +217,7 @@ describe('Validation Functions', () => {
         fertilizer_schedule: 'Monthly',
       }
 
-      const result = validateBloemFormData(validData)
+      const result = validatePlantFormData(validData)
 
       expect(result.isValid).toBe(true)
       expect(result.errors).toHaveLength(0)
@@ -229,7 +229,7 @@ describe('Validation Functions', () => {
         status: 'gezond' as const,
       }
 
-      const result = validateBloemFormData(invalidData)
+      const result = validatePlantFormData(invalidData)
 
       expect(result.isValid).toBe(false)
       expect(result.errors).toContainEqual({
@@ -245,7 +245,7 @@ describe('Validation Functions', () => {
         height: 50
       }
 
-      const result = validateBloemFormData(invalidData)
+      const result = validatePlantFormData(invalidData)
 
       expect(result.isValid).toBe(false)
       expect(result.errors).toContainEqual({
@@ -261,7 +261,7 @@ describe('Validation Functions', () => {
         height: -10
       }
 
-      const negativeResult = validateBloemFormData(negativeData)
+      const negativeResult = validatePlantFormData(negativeData)
 
       expect(negativeResult.isValid).toBe(false)
       expect(negativeResult.errors).toContainEqual({
@@ -278,7 +278,7 @@ describe('Validation Functions', () => {
         status: 'invalid-status' as any
       }
 
-      const result = validateBloemFormData(invalidData)
+      const result = validatePlantFormData(invalidData)
 
       expect(result.isValid).toBe(false)
       expect(result.errors).toContainEqual({
@@ -295,7 +295,7 @@ describe('Validation Functions', () => {
         status: 'gezond' as const,
       }
 
-      const result = validateBloemFormData(invalidDates)
+      const result = validatePlantFormData(invalidDates)
 
       expect(result.isValid).toBe(false)
       expect(result.errors.some(e => e.field === 'planting_date')).toBe(true)

--- a/app/gardens/[id]/plant-beds/[bedId]/plants/[plantId]/edit/page.tsx
+++ b/app/gardens/[id]/plant-beds/[bedId]/plants/[plantId]/edit/page.tsx
@@ -94,9 +94,9 @@ export default function EditPlantPage() {
 
     // Required fields
     if (!data.name.trim()) {
-      newErrors.name = "Bloemnaam is verplicht"
+              newErrors.name = "Plantnaam is verplicht"
     } else if (data.name.length > 100) {
-      newErrors.name = "Bloemnaam mag maximaal 100 karakters bevatten"
+              newErrors.name = "Plantnaam mag maximaal 100 karakters bevatten"
     }
 
     if (!data.color.trim()) {
@@ -301,7 +301,7 @@ export default function EditPlantPage() {
       <div className="mb-8">
         <h1 className="text-3xl font-bold text-gray-900 mb-2 flex items-center gap-2">
           <Leaf className="h-8 w-8 text-green-600" />
-          Bloem Bewerken
+          Plant Bewerken
         </h1>
         <div className="text-gray-600">
           <p>{plant.name}</p>
@@ -313,7 +313,7 @@ export default function EditPlantPage() {
         <div className="lg:col-span-2">
                       <Card>
               <CardHeader>
-                <CardTitle>Bloem Details</CardTitle>
+                <CardTitle>Plant Details</CardTitle>
               </CardHeader>
             <CardContent>
               <PlantForm

--- a/app/gardens/[id]/plant-beds/[bedId]/plants/new/page.tsx
+++ b/app/gardens/[id]/plant-beds/[bedId]/plants/new/page.tsx
@@ -72,9 +72,9 @@ export default function NewPlantPage() {
 
     // Required fields
     if (!data.name.trim()) {
-      newErrors.name = "Bloemnaam is verplicht"
+              newErrors.name = "Plantnaam is verplicht"
     } else if (data.name.length > 100) {
-      newErrors.name = "Bloemnaam mag maximaal 100 karakters bevatten"
+              newErrors.name = "Plantnaam mag maximaal 100 karakters bevatten"
     }
 
     if (!data.color.trim()) {
@@ -242,7 +242,7 @@ export default function NewPlantPage() {
       <div className="mb-8">
         <h1 className="text-3xl font-bold text-gray-900 mb-2 flex items-center gap-2">
           <Leaf className="h-8 w-8 text-green-600" />
-          Nieuwe Bloem Toevoegen
+          Nieuwe Plant Toevoegen
         </h1>
         <div className="text-gray-600">
           <p><strong>Tuin:</strong> {garden.name}</p>
@@ -253,7 +253,7 @@ export default function NewPlantPage() {
       {/* Plant Form */}
       <Card>
         <CardHeader>
-          <CardTitle>Bloem Details</CardTitle>
+                      <CardTitle>Plant Details</CardTitle>
         </CardHeader>
         <CardContent>
           <PlantForm
@@ -262,7 +262,7 @@ export default function NewPlantPage() {
             onChange={setPlantData}
             onSubmit={handleSubmit}
             onReset={handleReset}
-            submitLabel="Bloem toevoegen"
+                          submitLabel="Plant toevoegen"
             isSubmitting={loading}
             showAdvanced={true}
           />

--- a/app/gardens/[id]/plant-beds/page.tsx
+++ b/app/gardens/[id]/plant-beds/page.tsx
@@ -201,7 +201,7 @@ export default function PlantBedsPage() {
                         </div>
                       )}
                       <div className="flex justify-between">
-                        <span>Bloemen:</span>
+                        <span>Planten:</span>
                         <span>{bed.plants.length}</span>
                       </div>
                       {bed.soil_type && (
@@ -243,7 +243,7 @@ export default function PlantBedsPage() {
                       <div className="flex-1 min-w-0">
                         <h3 className="font-medium text-gray-900 truncate">{bed.name}</h3>
                         <div className="flex items-center gap-4 text-sm text-gray-600 mt-1">
-                          <span>{bed.plants.length} bloemen</span>
+                          <span>{bed.plants.length} planten</span>
                           {bed.size && <span>Grootte: {bed.size}</span>}
                           {bed.sun_exposure && (
                             <div className="flex items-center gap-1">
@@ -361,7 +361,7 @@ export default function PlantBedsPage() {
                 <div className="text-2xl font-bold text-blue-600">
                   {plantBeds.reduce((sum, bed) => sum + Math.max(1, bed.plants.length), 0)}
                 </div>
-                <div className="text-sm text-gray-600">Totaal Bloemen</div>
+                <div className="text-sm text-gray-600">Totaal Planten</div>
               </div>
               <div>
                 <div className="text-2xl font-bold text-purple-600">

--- a/app/logbook/[id]/edit/page.tsx
+++ b/app/logbook/[id]/edit/page.tsx
@@ -14,12 +14,12 @@ import { ArrowLeft, Calendar, Save, Upload, X, Image as ImageIcon } from "lucide
 import { LogbookService } from "@/lib/services/database.service"
 import { getPlantBeds } from "@/lib/database"
 import { uploadImage, type UploadResult } from "@/lib/storage"
-import type { LogbookEntryWithDetails, PlantvakWithBloemen } from "@/lib/types/index"
+import type { LogbookEntryWithDetails, PlantvakWithPlants } from "@/lib/types/index"
 import { format } from "date-fns"
 
 interface EditLogbookState {
   entry: LogbookEntryWithDetails | null
-  plantBeds: PlantvakWithBloemen[]
+  plantBeds: PlantvakWithPlants[]
   loading: boolean
   saving: boolean
   error: string | null
@@ -87,7 +87,7 @@ export default function EditLogbookPage() {
         setState(prev => ({
           ...prev,
           entry,
-          plantBeds: plantBeds as PlantvakWithBloemen[],
+          plantBeds: plantBeds as PlantvakWithPlants[],
           loading: false,
         }))
 

--- a/app/logbook/new/page.tsx
+++ b/app/logbook/new/page.tsx
@@ -17,14 +17,14 @@ import { LogbookService } from "@/lib/services/database.service"
 import { getPlantBeds, getPlantBed } from "@/lib/database"
 import { uploadImage, type UploadResult } from "@/lib/storage"
 import { uiLogger } from "@/lib/logger"
-import type { LogbookEntryFormData, Plantvak, Bloem, PlantvakWithBloemen } from "@/lib/types/index"
+import type { LogbookEntryFormData, Plantvak, Plant, PlantvakWithPlants } from "@/lib/types/index"
 import { ErrorBoundary } from "@/components/error-boundary"
 import { useToast } from "@/hooks/use-toast"
 import { format } from "date-fns"
 
 interface NewLogbookPageState {
-  plantBeds: PlantvakWithBloemen[]
-  plants: Bloem[]
+  plantBeds: PlantvakWithPlants[]
+  plants: Plant[]
   loading: boolean
   submitting: boolean
   uploadingPhoto: boolean
@@ -65,7 +65,7 @@ function NewLogbookPageContent() {
       const plantBeds = await getPlantBeds(gardenId)
 
       // Load plants if a plant bed is selected
-      let plants: Bloem[] = []
+      let plants: Plant[] = []
       if (state.formData.plant_bed_id) {
         const plantBedWithPlants = await getPlantBed(state.formData.plant_bed_id)
         if (plantBedWithPlants && plantBedWithPlants.plants) {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -18,7 +18,7 @@ import { TreePine, Plus, Search, MapPin, Calendar, Leaf, AlertCircle, Grid3X3, S
 import { TuinService } from "@/lib/services/database.service"
 import { getPlantBeds } from "@/lib/database"
 import { uiLogger, AuditLogger } from "@/lib/logger"
-import type { Tuin, PlantBedWithPlants, PlantvakWithBloemen } from "@/lib/types/index"
+import type { Tuin, PlantBedWithPlants, PlantvakWithPlants } from "@/lib/types/index"
 import { ErrorBoundary } from "@/components/error-boundary"
 import { useToast } from "@/hooks/use-toast"
 import { useAuth } from "@/hooks/use-supabase-auth"
@@ -381,7 +381,7 @@ interface GardenCardProps {
 }
 
 function GardenCard({ garden, onDelete, isListView = false }: GardenCardProps) {
-  const [plantBeds, setPlantBeds] = React.useState<PlantvakWithBloemen[]>([])
+  const [plantBeds, setPlantBeds] = React.useState<PlantvakWithPlants[]>([])
   const [loadingFlowers, setLoadingFlowers] = React.useState(true)
   const [gardenUsers, setGardenUsers] = React.useState<Array<{ id: string; email: string; full_name?: string }>>([])
   const [loadingUsers, setLoadingUsers] = React.useState(true)
@@ -426,7 +426,7 @@ function GardenCard({ garden, onDelete, isListView = false }: GardenCardProps) {
       try {
         setLoadingFlowers(true)
         const beds = await getPlantBeds(garden.id)
-        setPlantBeds(beds as PlantvakWithBloemen[])
+        setPlantBeds(beds as PlantvakWithPlants[])
       } catch (error) {
         uiLogger.error('Error loading flowers for garden preview', error as Error, { gardenId: garden.id })
         setPlantBeds([])
@@ -530,9 +530,9 @@ function GardenCard({ garden, onDelete, isListView = false }: GardenCardProps) {
           {/* Flower Preview Section */}
           <div className={isListView ? "mb-2" : "mb-4"}>
             <div className="flex items-center justify-between mb-2">
-              <span className="text-sm font-medium text-card-foreground">Bloemen in deze tuin:</span>
+                              <span className="text-sm font-medium text-card-foreground">Planten in deze tuin:</span>
               <span className="text-xs text-muted-foreground">
-                {plantBeds.reduce((total, bed) => total + (bed.plants?.length || 0), 0)} bloemen
+                                  {plantBeds.reduce((total, bed) => total + (bed.plants?.length || 0), 0)} planten
               </span>
             </div>
             

--- a/app/plants/[id]/page.tsx
+++ b/app/plants/[id]/page.tsx
@@ -11,10 +11,10 @@ import { AddTaskForm } from '@/components/tasks/add-task-form'
 import { TaskService } from '@/lib/services/task.service'
 import { supabase } from '@/lib/supabase'
 import type { TaskWithPlantInfo } from '@/lib/types/tasks'
-import type { Bloem } from '@/lib/types/index'
+import type { Plant } from '@/lib/types/index'
 import { PlantPhotoGallery } from '@/components/plant-photo-gallery'
 
-interface PlantWithBeds extends Bloem {
+interface PlantWithBeds extends Plant {
   plant_beds?: {
     name: string
     sun_exposure?: string
@@ -163,8 +163,8 @@ export default function PlantDetailPage() {
         <Card>
           <CardContent className="p-8 text-center">
             <AlertCircle className="w-12 h-12 text-red-500 mx-auto mb-4" />
-            <h3 className="text-lg font-medium text-gray-900 mb-2">Bloem niet gevonden</h3>
-            <p className="text-gray-600 mb-4">De bloem die je zoekt bestaat niet of is verwijderd.</p>
+            <h3 className="text-lg font-medium text-gray-900 mb-2">Plant niet gevonden</h3>
+                          <p className="text-gray-600 mb-4">De plant die je zoekt bestaat niet of is verwijderd.</p>
             <Button asChild>
               <Link href="/">Terug naar overzicht</Link>
             </Button>
@@ -224,13 +224,13 @@ export default function PlantDetailPage() {
             <CardHeader>
               <CardTitle className="flex items-center gap-2 text-green-800">
                 <Leaf className="w-5 h-5" />
-                Basis Bloemgegevens
+                Basis Plantgegevens
               </CardTitle>
             </CardHeader>
             <CardContent className="space-y-4">
               <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                 <div>
-                  <label className="text-sm font-medium text-gray-700">Bloemnaam</label>
+                  <label className="text-sm font-medium text-gray-700">Plantnaam</label>
                   <p className="text-lg font-semibold flex items-center gap-2">
                     {plant.emoji && <span className="text-xl">{plant.emoji}</span>}
                     {plant.name}

--- a/lib/services/database.service.ts
+++ b/lib/services/database.service.ts
@@ -3,8 +3,8 @@ import { databaseLogger, AuditLogger, PerformanceLogger } from '../logger'
 import type { 
   Tuin, 
   Plantvak, 
-  Bloem, 
-  PlantvakWithBloemen, 
+  Plant, 
+  PlantvakWithPlants, 
   TuinWithPlantvakken,
   LogbookEntry,
   LogbookEntryWithDetails,
@@ -1024,5 +1024,5 @@ export class LogbookService {
 export const DatabaseService = {
   Tuin: TuinService,
   Logbook: LogbookService,
-  // TODO: Add PlantvakService and BloemService following the same pattern
+  // TODO: Add PlantvakService and PlantService following the same pattern
 }

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -49,7 +49,7 @@ export interface Plantvak {
   visual_updated_at?: string
 }
 
-export interface Bloem {
+export interface Plant {
   id: string
   plant_bed_id: string
   name: string
@@ -129,7 +129,7 @@ export interface PlantvakFormData {
   description: string
 }
 
-export interface BloemFormData {
+export interface PlantFormData {
   name: string
   latin_name?: string
   scientific_name?: string
@@ -158,12 +158,12 @@ export interface LogbookEntryFormData {
 }
 
 // Composite Types
-export interface PlantvakWithBloemen extends Plantvak {
-  plants: Bloem[]
+export interface PlantvakWithPlants extends Plantvak {
+  plants: Plant[]
 }
 
 export interface TuinWithPlantvakken extends Tuin {
-  plant_beds: PlantvakWithBloemen[]
+  plant_beds: PlantvakWithPlants[]
 }
 
 // Visual Garden Types
@@ -291,7 +291,7 @@ export interface User {
 }
 
 // Additional Types
-export interface PlantWithPosition extends Bloem {
+export interface PlantWithPosition extends Plant {
   position_x: number
   position_y: number
   visual_width: number
@@ -302,8 +302,6 @@ export interface PlantWithPosition extends Bloem {
 // Legacy type aliases for backward compatibility
 export type Garden = Tuin
 export type PlantBed = Plantvak
-export type Plant = Bloem
 export type PlantBedFormData = PlantvakFormData
-export type PlantFormData = BloemFormData
-export type PlantBedWithPlants = PlantvakWithBloemen
+export type PlantBedWithPlants = PlantvakWithPlants
 export type PlantBedPosition = PlantvakPosition

--- a/lib/validation/index.ts
+++ b/lib/validation/index.ts
@@ -1,7 +1,7 @@
 import type { 
   TuinFormData, 
   PlantvakFormData, 
-  BloemFormData, 
+  PlantFormData, 
   ValidationError, 
   ValidationResult 
 } from '../types/index'
@@ -293,7 +293,7 @@ export function validatePlantvakFormData(data: Partial<PlantvakFormData>): Valid
   return validator.getResult()
 }
 
-export function validateBloemFormData(data: Partial<BloemFormData>): ValidationResult {
+export function validatePlantFormData(data: Partial<PlantFormData>): ValidationResult {
   const validator = new Validator()
 
   // Required fields validation


### PR DESCRIPTION
Rename 'bloem' to 'plant' across the codebase for consistent terminology.

---
<a href="https://cursor.com/background-agent?bcId=bc-cd9c94e2-5bac-4aa6-b58a-ee666d4f0685">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-cd9c94e2-5bac-4aa6-b58a-ee666d4f0685">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

