### PR TITLE
Set main to preview branch

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -438,7 +438,7 @@ jobs:
     needs: [quality, security, regression, build, dast]
     if: |
       (needs.changes.outputs.code == 'true' || github.event_name == 'pull_request') &&
-      (github.event_name == 'pull_request' || startsWith(github.ref, 'refs/heads/feature/') || startsWith(github.ref, 'refs/heads/bugfix/') || startsWith(github.ref, 'refs/heads/preview/')) &&
+      (github.event_name == 'pull_request' || startsWith(github.ref, 'refs/heads/feature/') || startsWith(github.ref, 'refs/heads/bugfix/') || startsWith(github.ref, 'refs/heads/preview/') || github.ref == 'refs/heads/main') &&
       needs.quality.result == 'success' &&
       needs.security.result == 'success' &&
       needs.regression.result == 'success' &&


### PR DESCRIPTION
Add `main` branch to preview deployment to ensure it is also deployed to preview environments.

---
<a href="https://cursor.com/background-agent?bcId=bc-370f4988-9890-45fe-8418-a9d1fb85b0d1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-370f4988-9890-45fe-8418-a9d1fb85b0d1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

