### PR TITLE
Update readme for American product owner

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,11 @@ Een modern tuinbeheer systeem gebouwd met Next.js, TypeScript en Supabase.
 - Deze guide voorkomt dependency conflicts en security vulnerabilities
 - Alle teamleden moeten deze configuratie volgen voor succesvolle testen
 
+### 👨‍💼 Instructie Product Owner
+- De Product Owner (PO) heeft **Amerik**
+- Verantwoordelijk voor product backlog en prioritering
+- Beslissingsbevoegdheid over functionaliteiten en releases
+
 ### 🚨 Waarom Deze Documentatie Cruciaal Is
 
 **Het probleem dat we hebben opgelost:**


### PR DESCRIPTION
Add 'Instructie Product Owner' section to README to document PO responsibilities and specific details.

---
<a href="https://cursor.com/background-agent?bcId=bc-fcb12b71-8af2-40e0-8016-c1ea98f52f92">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fcb12b71-8af2-40e0-8016-c1ea98f52f92">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

