### PR TITLE
refactor: consolidate node setup with composite action

### DIFF
--- a/.github/workflows/ai-code-quality-review.yml
+++ b/.github/workflows/ai-code-quality-review.yml
@@ -15,22 +15,17 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - name: Checkout PR HEAD
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha }}
-
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: ./.github/workflows/setup-node.yml
         with:
           node-version: 20
+      - name: Fetch full history
+        run: git fetch --prune --unshallow
+      - name: Checkout PR commit
+        run: git checkout ${{ github.event.pull_request.head.sha }}
 
       - name: Install deps
-        run: |
-          npm init -y >/dev/null 2>&1
-
-          npm i --no-fund --no-audit openai @octokit/rest @actions/core
+        run: npm i --no-fund --no-audit openai @octokit/rest @actions/core
 
       - name: Run AI Code Quality Review
         env:

--- a/.github/workflows/ai-pipeline-v2.yml
+++ b/.github/workflows/ai-pipeline-v2.yml
@@ -32,17 +32,12 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-      - name: 📥 Checkout code
-        uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          fetch-depth: 0
-
-      - name: 🟢 Setup Node.js
-        uses: actions/setup-node@v4
+      - name: 🟢 Setup Node
+        uses: ./.github/workflows/setup-node.yml
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: 'npm'
+      - name: Fetch full history
+        run: git fetch --prune --unshallow
 
       - name: 📦 Install AI Pipeline v2
         run: |

--- a/.github/workflows/ai-security-review.yml
+++ b/.github/workflows/ai-security-review.yml
@@ -14,21 +14,17 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - name: Checkout PR HEAD
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha }}
-
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: ./.github/workflows/setup-node.yml
         with:
           node-version: 20
+      - name: Fetch full history
+        run: git fetch --prune --unshallow
+      - name: Checkout PR commit
+        run: git checkout ${{ github.event.pull_request.head.sha }}
 
       - name: Install deps
-        run: |
-          npm init -y >/dev/null 2>&1
-          npm i --no-fund --no-audit openai @octokit/rest @actions/core
+        run: npm i --no-fund --no-audit openai @octokit/rest @actions/core
 
       - name: Sanity check env
         run: |

--- a/.github/workflows/main-pipeline.yml
+++ b/.github/workflows/main-pipeline.yml
@@ -21,17 +21,10 @@ jobs:
     timeout-minutes: 10
     
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-      
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+      - name: Setup Node
+        uses: ./.github/workflows/setup-node.yml
         with:
           node-version: '18'
-          cache: 'npm'
-      
-      - name: Install dependencies
-        run: npm ci
       
       - name: Build project
         run: npm run build
@@ -51,17 +44,10 @@ jobs:
     timeout-minutes: 8
     
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-      
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+      - name: Setup Node
+        uses: ./.github/workflows/setup-node.yml
         with:
           node-version: '18'
-          cache: 'npm'
-      
-      - name: Install dependencies
-        run: npm ci
       
       - name: Build for preview
         run: npm run build
@@ -132,17 +118,10 @@ jobs:
     timeout-minutes: 20
     
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-      
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+      - name: Setup Node
+        uses: ./.github/workflows/setup-node.yml
         with:
           node-version: '18'
-          cache: 'npm'
-      
-      - name: Install dependencies
-        run: npm ci
       
       - name: Run Complete Banking Standards Test Suite
         run: |
@@ -455,19 +434,12 @@ jobs:
       actions: read
     
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+      - name: Setup Node
+        uses: ./.github/workflows/setup-node.yml
         with:
           node-version: '18'
-          cache: 'npm'
-      
-      - name: Install dependencies
-        run: npm ci
+      - name: Ensure full history
+        run: git fetch --prune --unshallow
       
       - name: Install AI Standards Agent
         run: |

--- a/.github/workflows/setup-node.yml
+++ b/.github/workflows/setup-node.yml
@@ -1,0 +1,20 @@
+name: Setup Node
+description: Checkout repository, setup Node.js and install dependencies
+inputs:
+  node-version:
+    description: Node.js version to use
+    required: false
+    default: '18'
+runs:
+  using: 'composite'
+  steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ inputs.node-version }}
+        cache: 'npm'
+    - name: Install dependencies
+      run: npm ci
+      shell: bash


### PR DESCRIPTION
## Summary
- add reusable setup-node composite action for checkout, node setup and dependency install
- use setup-node action across main and AI workflows to remove duplicate steps

## Testing
- `npm test` *(fails: Tests failed. Watching for file changes...)*
- `npm run lint` *(fails: 74 errors, 760 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a5e777fb4c8326a3a18dfbac63ce61