### PR TITLE
test: wrap useAuth hook with provider

### DIFF
--- a/hooks/use-supabase-auth.ts
+++ b/hooks/use-supabase-auth.ts
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect, createContext, useContext } from 'react'
+import React, { useState, useEffect, createContext, useContext, type ReactNode } from 'react'
 import { getSupabaseClient } from '@/lib/supabase'
 import { clearStaleCache } from '@/lib/version'
 import type { User as SupabaseUser, Session } from '@supabase/supabase-js'
@@ -654,6 +654,15 @@ export function useSupabaseAuth(): AuthContextType {
 }
 
 export const SupabaseAuthContext = createContext<AuthContextType | null>(null)
+
+export function SupabaseAuthProvider({ children }: { children: ReactNode }) {
+  const auth = useSupabaseAuth()
+  return React.createElement(
+    SupabaseAuthContext.Provider,
+    { value: auth },
+    children
+  )
+}
 
 export function useAuth(): AuthContextType {
   const context = useContext(SupabaseAuthContext)


### PR DESCRIPTION
## Summary
- test useSupabaseAuth hook within SupabaseAuthProvider
- export simple SupabaseAuthProvider from auth hook

## Testing
- `npm test __tests__/hooks/use-supabase-auth.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68a60b5849b08326a04e3533ba06965c