### PR TITLE
feat: add production deployment job

### DIFF
--- a/.github/workflows/main-pipeline.yml
+++ b/.github/workflows/main-pipeline.yml
@@ -501,3 +501,13 @@ jobs:
           echo "- AI-powered code analysis and issue detection" >> $GITHUB_STEP_SUMMARY
           echo "- Automatic code fixing and quality improvement" >> $GITHUB_STEP_SUMMARY
           echo "- Quality cycles until 80%+ threshold reached" >> $GITHUB_STEP_SUMMARY
+
+  deploy-production:
+    runs-on: ubuntu-latest
+    name: 🚀 Deploy Production
+    needs: [unified-summary]
+    environment: production
+
+    steps:
+      - name: Deploy
+        run: echo "Deploying to production..."

--- a/.github/workflows/main-pipeline.yml
+++ b/.github/workflows/main-pipeline.yml
@@ -369,7 +369,7 @@ jobs:
     runs-on: ubuntu-latest
     name: 📋 Unified Summary
     needs: [foundation-build, preview-build, docker-build, conventional-tests, ai-code-check]
-    if: always() && github.event_name == 'pull_request'
+    if: always()
     timeout-minutes: 5
     permissions:
       contents: read
@@ -424,6 +424,7 @@ jobs:
           echo "✅ Simple summary created"
       
       - name: Post Summary Comment
+        if: github.event_name == 'pull_request'
         uses: actions/github-script@v7
         with:
           script: |
@@ -487,7 +488,7 @@ jobs:
           echo "### ✅ All Jobs Completed" >> $GITHUB_STEP_SUMMARY
           echo "- **Foundation Build**: ✅ SUCCESS" >> $GITHUB_STEP_SUMMARY
           echo "- **Preview Build**: ✅ READY" >> $GITHUB_STEP_SUMMARY
-                      echo "- **Docker Build**: ✅ VERIFIED (image built successfully)" >> $GITHUB_STEP_SUMMARY
+          echo "- **Docker Build**: ✅ VERIFIED (image built successfully)" >> $GITHUB_STEP_SUMMARY
           echo "- **Conventional Tests**: ✅ COMPLETED" >> $GITHUB_STEP_SUMMARY
           echo "- **AI Code Check**: ✅ COMPLETED" >> $GITHUB_STEP_SUMMARY
           echo "- **Unified Summary**: ✅ POSTED" >> $GITHUB_STEP_SUMMARY
@@ -506,6 +507,7 @@ jobs:
     runs-on: ubuntu-latest
     name: 🚀 Deploy Production
     needs: [unified-summary]
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     environment: production
 
     steps:


### PR DESCRIPTION
## Summary
- add deploy-production job that runs after unified-summary and targets the `production` environment

## Testing
- `npm test` *(fails: 22 failed, 40 passed, 11 skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68a60f6144ec832697560063a1bc23db