### PR TITLE
refactor: update supabase client mocks in tests

### DIFF
--- a/__tests__/setup/supabase-mock.ts
+++ b/__tests__/setup/supabase-mock.ts
@@ -330,7 +330,7 @@ export function createMockSupabase() {
 jest.mock('@/lib/supabase', () => {
   const { createMockSupabase } = require('@/__tests__/setup/supabase-mock')
   return {
-    supabase: createMockSupabase(),
+    getSupabaseClient: jest.fn(() => createMockSupabase()),
   }
 })
 

--- a/__tests__/unit/app/api/gardens/route.test.ts
+++ b/__tests__/unit/app/api/gardens/route.test.ts
@@ -46,7 +46,7 @@ const mockLogClientSecurityEvent = require('@/lib/banking-security').logClientSe
 const mockValidateApiInput = require('@/lib/banking-security').validateApiInput;
 const mockValidateTuinFormData = require('@/lib/validation').validateTuinFormData;
 
-describe.skip('Gardens API Route', () => {
+describe('Gardens API Route', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     

--- a/__tests__/unit/app/api/plant-beds/route.test.ts
+++ b/__tests__/unit/app/api/plant-beds/route.test.ts
@@ -19,7 +19,7 @@ jest.mock('@/lib/logger', () => ({
 const mockSupabase = require('@/lib/supabase').supabase;
 const mockApiLogger = require('@/lib/logger').apiLogger;
 
-describe.skip('Plant Beds API Route', () => {
+describe('Plant Beds API Route', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });

--- a/__tests__/unit/components/error-boundary.test.tsx
+++ b/__tests__/unit/components/error-boundary.test.tsx
@@ -27,7 +27,7 @@ const CustomFallback = ({ error, reset }: { error: Error; reset: () => void }) =
   </div>
 )
 
-describe.skip('ErrorBoundary', () => {
+describe('ErrorBoundary', () => {
   beforeEach(() => {
     jest.clearAllMocks()
     mockLocation.href = ''

--- a/__tests__/unit/components/theme-toggle.test.tsx
+++ b/__tests__/unit/components/theme-toggle.test.tsx
@@ -10,7 +10,7 @@ jest.mock('next-themes', () => ({
 
 const mockUseTheme = useTheme as jest.MockedFunction<typeof useTheme>
 
-describe.skip('ThemeToggle', () => {
+describe('ThemeToggle', () => {
   const mockSetTheme = jest.fn()
 
   beforeEach(() => {

--- a/__tests__/unit/components/ui/input-otp.test.tsx
+++ b/__tests__/unit/components/ui/input-otp.test.tsx
@@ -49,7 +49,7 @@ jest.mock('lucide-react', () => ({
   )
 }));
 
-describe.skip('InputOTP Components', () => {
+describe('InputOTP Components', () => {
   describe('InputOTP', () => {
     it('should render with default props', () => {
       render(<InputOTP />);

--- a/__tests__/unit/components/ui/use-toast.test.ts
+++ b/__tests__/unit/components/ui/use-toast.test.ts
@@ -8,7 +8,7 @@ jest.mock('@/components/ui/toast', () => ({
   ToastProps: jest.fn()
 }));
 
-describe.skip('use-toast', () => {
+describe('use-toast', () => {
   beforeEach(() => {
     // Clear any existing timeouts
     jest.clearAllTimers();

--- a/__tests__/unit/lib/api-auth-wrapper.test.ts
+++ b/__tests__/unit/lib/api-auth-wrapper.test.ts
@@ -13,7 +13,7 @@ jest.mock('@/lib/banking-security', () => ({
   logClientSecurityEvent: jest.fn()
 }));
 
-describe.skip('API Auth Wrapper', () => {
+describe('API Auth Wrapper', () => {
   let mockSupabase: any;
   let mockLogClientSecurityEvent: any;
 

--- a/__tests__/unit/lib/database.test.ts
+++ b/__tests__/unit/lib/database.test.ts
@@ -1,15 +1,20 @@
 import { DatabaseService } from '@/lib/services/database.service'
-import { supabase } from '@/lib/supabase'
+import { getSupabaseClient } from '@/lib/supabase'
 import * as database from '@/lib/database'
 
 // Mock dependencies
 jest.mock('@/lib/services/database.service')
-jest.mock('@/lib/supabase')
+jest.mock('@/lib/supabase', () => ({
+  getSupabaseClient: jest.fn(() => ({
+    from: jest.fn(),
+  })),
+}))
 
+const supabase = getSupabaseClient()
 const mockDatabaseService = DatabaseService as jest.Mocked<typeof DatabaseService>
-const mockSupabase = supabase as jest.Mocked<typeof supabase>
+const mockSupabase = supabase as any
 
-describe.skip('Database Functions', () => {
+describe('Database Functions', () => {
   beforeEach(() => {
     jest.clearAllMocks()
     jest.spyOn(console, 'log').mockImplementation(() => {})

--- a/__tests__/unit/lib/logger.test.ts
+++ b/__tests__/unit/lib/logger.test.ts
@@ -9,7 +9,7 @@ const mockConsole = {
   log: jest.fn(),
 };
 
-describe.skip('Logger', () => {
+describe('Logger', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     Object.assign(console, mockConsole);

--- a/__tests__/unit/lib/password-change-manager.test.ts
+++ b/__tests__/unit/lib/password-change-manager.test.ts
@@ -1,5 +1,5 @@
 jest.mock('@/lib/supabase', () => ({
-  supabase: {
+  getSupabaseClient: jest.fn(() => ({
     auth: {
       getUser: jest.fn(),
       signInWithPassword: jest.fn(),
@@ -9,10 +9,11 @@ jest.mock('@/lib/supabase', () => ({
         updateUserById: jest.fn(),
       },
     },
-  },
+  })),
 }));
 
-import { supabase } from '@/lib/supabase';
+import { getSupabaseClient } from '@/lib/supabase';
+const supabase = getSupabaseClient();
 import { passwordChangeManager } from '@/lib/password-change-manager';
 
 describe('PasswordChangeManager', () => {

--- a/__tests__/unit/lib/scaling-constants.test.ts
+++ b/__tests__/unit/lib/scaling-constants.test.ts
@@ -17,7 +17,7 @@ import {
   calculatePlantBedCanvasSize
 } from '@/lib/scaling-constants';
 
-describe.skip('Scaling Constants', () => {
+describe('Scaling Constants', () => {
   describe('Constants', () => {
     it('should have correct base scaling', () => {
       expect(METERS_TO_PIXELS).toBe(80);

--- a/__tests__/unit/lib/services/database.service.test.ts
+++ b/__tests__/unit/lib/services/database.service.test.ts
@@ -58,7 +58,7 @@ jest.mock('@/lib/logger', () => ({
   }
 }));
 
-describe.skip('Database Service', () => {
+describe('Database Service', () => {
   describe('Error Classes', () => {
     describe('DatabaseError', () => {
       it('should create DatabaseError with message', () => {

--- a/__tests__/unit/lib/services/task.service.test.ts
+++ b/__tests__/unit/lib/services/task.service.test.ts
@@ -56,7 +56,7 @@ jest.mock('@/lib/security/garden-access', () => ({
   filterAccessibleGardens: jest.fn((gardens) => gardens)
 }));
 
-describe.skip('Task Service', () => {
+describe('Task Service', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });

--- a/__tests__/unit/lib/version.test.ts
+++ b/__tests__/unit/lib/version.test.ts
@@ -54,7 +54,7 @@ afterAll(() => {
   console.log = originalConsoleLog;
 });
 
-describe.skip('Version Utilities', () => {
+describe('Version Utilities', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     localStorageMock.store = {};

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -92,33 +92,38 @@ vi.mock('next/font/google', () => ({
 }));
 
 // Mock Supabase
-vi.mock('@/lib/supabase', () => ({
-  getSupabaseClient: vi.fn(() => ({
-    auth: {
-      getUser: vi.fn().mockResolvedValue({ data: { user: null }, error: null }),
-      signInWithPassword: vi.fn().mockResolvedValue({ data: { user: null }, error: null }),
-      signUp: vi.fn().mockResolvedValue({ data: { user: null }, error: null }),
-      signOut: vi.fn().mockResolvedValue({ error: null }),
-      onAuthStateChange: vi.fn().mockReturnValue({ data: { subscription: null } }),
-    },
-    from: vi.fn(() => ({
-      select: vi.fn(() => ({
-        eq: vi.fn(() => ({
-          single: vi.fn().mockResolvedValue({ data: null, error: null }),
-          maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
+vi.mock('@/lib/supabase', () => {
+  const chain: any = {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    insert: vi.fn().mockReturnThis(),
+    update: vi.fn().mockReturnThis(),
+    delete: vi.fn().mockReturnThis(),
+    limit: vi.fn().mockReturnThis(),
+    order: vi.fn().mockReturnThis(),
+    range: vi.fn().mockReturnThis(),
+    rpc: vi.fn().mockReturnThis(),
+    then: vi.fn().mockResolvedValue({ data: null, error: null }),
+  };
+  return {
+    getSupabaseClient: vi.fn(() => ({
+      auth: {
+        getUser: vi.fn().mockResolvedValue({ data: { user: null }, error: null }),
+        signInWithPassword: vi.fn().mockResolvedValue({ data: { user: null }, error: null }),
+        signUp: vi.fn().mockResolvedValue({ data: { user: null }, error: null }),
+        signOut: vi.fn().mockResolvedValue({ error: null }),
+        onAuthStateChange: vi.fn().mockReturnValue({ data: { subscription: null } }),
+      },
+      from: vi.fn(() => chain),
+      storage: {
+        from: vi.fn(() => ({
+          upload: vi.fn().mockResolvedValue({ data: null, error: null }),
+          download: vi.fn().mockResolvedValue({ data: null, error: null }),
+          remove: vi.fn().mockResolvedValue({ data: null, error: null }),
+          list: vi.fn().mockResolvedValue({ data: null, error: null }),
         })),
-        insert: vi.fn().mockResolvedValue({ data: null, error: null }),
-        update: vi.fn().mockResolvedValue({ data: null, error: null }),
-        delete: vi.fn().mockResolvedValue({ data: null, error: null }),
-      })),
+      },
+      rpc: vi.fn().mockReturnValue(chain),
     })),
-    storage: {
-      from: vi.fn(() => ({
-        upload: vi.fn().mockResolvedValue({ data: null, error: null }),
-        download: vi.fn().mockResolvedValue({ data: null, error: null }),
-        remove: vi.fn().mockResolvedValue({ data: null, error: null }),
-        list: vi.fn().mockResolvedValue({ data: null, error: null }),
-      })),
-    },
-  })),
-}));
+  };
+});


### PR DESCRIPTION
## Summary
- replace direct `supabase` imports in tests with `getSupabaseClient`
- mock `getSupabaseClient` with chainable methods for tests
- enable previously skipped unit test suites

## Testing
- `npm run test:unit` *(fails: multiple component and API tests)*
- `npm run test:integration` *(fails: no test files found)*

------
https://chatgpt.com/codex/tasks/task_e_68a622122004832683da49b12bcc86fb