### PR TITLE
ci: make unified summary optional for AI jobs

### DIFF
--- a/.github/workflows/main-pipeline.yml
+++ b/.github/workflows/main-pipeline.yml
@@ -422,12 +422,8 @@ jobs:
     # Aggregates build, test, security, and AI results into one report
     needs:
       - foundation-build
-      - preview-build
-      - docker-build
       - conventional-tests
-      - ai-code-check
-      - ai-security-review
-      - ai-code-quality-review
+      - security-scan
     if: always() && github.event_name == 'pull_request'
     timeout-minutes: 5
     permissions:
@@ -455,6 +451,7 @@ jobs:
         continue-on-error: true
 
       - name: Download AI Results
+        if: ${{ env.OPENAI_API_KEY != '' }}
         uses: actions/download-artifact@v4
         with:
           name: ai-standards-results


### PR DESCRIPTION
## Summary
- limit unified summary dependencies to required build, test and security jobs
- only download AI results when an API key is present

## Testing
- `npm test` *(fails: Test Files 48 failed | 65 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68a62c00ebf48326890ac50c25eadd4e