### PR TITLE
Fix ci/cd workflow secrets error

### DIFF
--- a/.github/workflows/ai-pipeline-v2.yml
+++ b/.github/workflows/ai-pipeline-v2.yml
@@ -29,10 +29,18 @@ env:
 jobs:
   ai-pipeline-v2:
     name: 🚀 AI Pipeline v2.0
-    if: ${{ secrets.OPENAI_API_KEY != '' }}
     runs-on: ubuntu-latest
     
     steps:
+      - name: 🔑 Check OpenAI API Key
+        run: |
+          if [ -z "${{ secrets.OPENAI_API_KEY }}" ]; then
+            echo "❌ Error: OPENAI_API_KEY secret is not set"
+            echo "Please add the OPENAI_API_KEY secret to your repository settings"
+            exit 1
+          fi
+          echo "✅ OpenAI API Key is configured"
+      
       - name: 🟢 Setup Node
         uses: ./.github/actions/setup-node
         with:


### PR DESCRIPTION
Fixes "Unrecognized named-value: 'secrets'" error in AI pipeline workflow by moving secret check to a step.

The `secrets` context is not accessible in job-level `if` conditions. This PR removes the problematic job-level `if` statement and introduces an initial step that checks for the `OPENAI_API_KEY` using a shell script, failing early if the secret is not configured.

---
<a href="https://cursor.com/background-agent?bcId=bc-2b86f3c6-0e8c-47e1-975e-76a09a11962e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2b86f3c6-0e8c-47e1-975e-76a09a11962e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

