### PR TITLE
Fix invalid ci-cd workflow file

### DIFF
--- a/.github/workflow-archive/ci-cd.yml.disabled
+++ b/.github/workflow-archive/ci-cd.yml.disabled
@@ -8,7 +8,6 @@ on:
 
 env:
   NODE_VERSION: '18'
-  NPM_CACHE_KEY: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
 
 jobs:
   # Quality Checks


### PR DESCRIPTION
Remove `NPM_CACHE_KEY` from global environment to fix workflow syntax error and leverage automatic cache key generation.

---
<a href="https://cursor.com/background-agent?bcId=bc-a780ebb7-e0a5-4fbd-b590-fcbd40a7b368">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a780ebb7-e0a5-4fbd-b590-fcbd40a7b368">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

