### PR TITLE
chore(ci): output vitest junit reports

### DIFF
--- a/.github/workflows/main-pipeline.yml
+++ b/.github/workflows/main-pipeline.yml
@@ -199,16 +199,16 @@ jobs:
         run: mkdir -p test-results
 
       - name: Run unit tests
-        run: npm run test:unit
+        run: vitest --reporter=junit --outputFile test-results/unit.xml
 
       - name: Run integration tests
-        run: npm run test:integration
+        run: vitest '__tests__/integration/**/*.{test,spec}.{ts,tsx}' --reporter=junit --outputFile test-results/integration.xml
 
       - name: Run critical endpoint tests
-        run: npm run test:critical-endpoints
+        run: vitest '__tests__/components/**/*.{test,spec}.{ts,tsx}' --reporter=junit --outputFile test-results/critical-endpoints.xml
 
       - name: Run end-to-end tests
-        run: npm run test:e2e
+        run: vitest --reporter=junit --outputFile test-results/e2e.xml
 
       - name: Upload test results
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- capture vitest output as JUnit XML for unit, integration, critical endpoint and e2e tests
- ensure conventional test results upload includes generated reports

## Testing
- `npm run test:unit` *(fails: Objects are not valid as a React child ...)*

------
https://chatgpt.com/codex/tasks/task_e_68a6a14069bc83268f8cb47d06de3e07