### PR TITLE
Handle plantvak open error

### DIFF
--- a/app/gardens/[id]/page.tsx
+++ b/app/gardens/[id]/page.tsx
@@ -28,7 +28,7 @@ import {
   Cloud,
   Trash2,
 } from "lucide-react"
-import { getGarden, getPlantBeds, createPlantBed, updatePlantBed, deletePlantBed } from "@/lib/database"
+import { getGarden, getPlantBedsWithPlants, createPlantBed, updatePlantBed, deletePlantBed } from "@/lib/database"
 import type { Garden, PlantBedWithPlants } from "@/lib/supabase"
 import { 
   METERS_TO_PIXELS, 
@@ -129,7 +129,7 @@ export default function GardenDetailPage() {
         setLoading(true)
         const [gardenData, plantBedsData] = await Promise.all([
           getGarden(params.id as string),
-          getPlantBeds(params.id as string),
+          getPlantBedsWithPlants(params.id as string),
         ])
         console.log("✅ Garden loaded:", { id: gardenData?.id, name: gardenData?.name })
         setGarden(gardenData)
@@ -717,7 +717,7 @@ export default function GardenDetailPage() {
                               containerWidth={bedWidth}
                               containerHeight={bedHeight}
                             />
-                            {bed.plants.length === 0 && (
+                            {(bed.plants?.length || 0) === 0 && (
                               <div className="text-gray-500 text-sm font-medium bg-white/80 px-3 py-2 rounded-lg border border-gray-300 shadow-sm">
                                 🌱 Leeg plantvak
                               </div>
@@ -737,7 +737,7 @@ export default function GardenDetailPage() {
                         <div className="mt-1 text-center">
                           <div className="text-xs text-gray-600 font-medium">{bed.name}</div>
                           <div className="text-xs text-gray-500">
-                            {bed.size || `${(bedWidth / METERS_TO_PIXELS).toFixed(1)}m × ${(bedHeight / METERS_TO_PIXELS).toFixed(1)}m`} • {bed.plants.length} 🌸
+                            {bed.size || `${(bedWidth / METERS_TO_PIXELS).toFixed(1)}m × ${(bedHeight / METERS_TO_PIXELS).toFixed(1)}m`} • {bed.plants?.length || 0} 🌸
                           </div>
                         </div>
                       </div>
@@ -828,15 +828,15 @@ export default function GardenDetailPage() {
                           </div>
                         )}
                         <div>
-                          {bed.plants.length} bloemen
+                          {bed.plants?.length || 0} bloemen
                         </div>
                       </div>
                       
                       {/* Flower preview in plant bed list */}
-                      {bed.plants.length > 0 && (
+                      {(bed.plants?.length || 0) > 0 && (
                         <div className="mt-2">
                           <div className="flex flex-wrap gap-1">
-                            {bed.plants.slice(0, 4).map((flower, index) => (
+                            {(bed.plants || []).slice(0, 4).map((flower, index) => (
                               <div
                                 key={`${flower.id}-${index}`}
                                 className="flex items-center gap-1 bg-purple-50 border border-purple-200 rounded-lg px-2 py-1"
@@ -857,10 +857,10 @@ export default function GardenDetailPage() {
                                 )}
                               </div>
                             ))}
-                            {bed.plants.length > 4 && (
+                            {(bed.plants?.length || 0) > 4 && (
                               <div className="flex items-center justify-center bg-gray-100 border border-gray-200 rounded-lg px-2 py-1">
                                 <span className="text-xs text-gray-600">
-                                  +{bed.plants.length - 4}
+                                  +{(bed.plants?.length || 0) - 4}
                                 </span>
                               </div>
                             )}
@@ -869,7 +869,7 @@ export default function GardenDetailPage() {
                       )}
                     </div>
                     <Badge variant="secondary" className="bg-green-100 text-green-800">
-                      {bed.plants.length > 0 ? 'Beplant' : 'Leeg'}
+                      {(bed.plants?.length || 0) > 0 ? 'Beplant' : 'Leeg'}
                     </Badge>
                   </div>
                 </CardHeader>
@@ -921,7 +921,7 @@ export default function GardenDetailPage() {
                   </span>
                 </div>
                 <div className="text-sm text-red-700">
-                  {plantBeds.find(bed => bed.id === deletingBedId)?.plants.length || 0} bloemen zullen ook worden verwijderd
+                  {plantBeds.find(bed => bed.id === deletingBedId)?.plants?.length || 0} bloemen zullen ook worden verwijderd
                 </div>
               </div>
             </div>

--- a/app/gardens/[id]/plant-beds/page.tsx
+++ b/app/gardens/[id]/plant-beds/page.tsx
@@ -9,7 +9,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { ArrowLeft, TreePine, Plus, Search, Eye, Leaf, Sun, MapPin, Grid3X3, BookOpen } from "lucide-react"
-import { getGarden, getPlantBeds } from "@/lib/database"
+import { getGarden, getPlantBedsWithPlants } from "@/lib/database"
 import type { Garden, PlantBedWithPlants } from "@/lib/supabase"
 import { useToast } from "@/hooks/use-toast"
 
@@ -29,7 +29,7 @@ export default function PlantBedsPage() {
         setLoading(true)
         const [gardenData, plantBedsData] = await Promise.all([
           getGarden(params.id as string),
-          getPlantBeds(params.id as string),
+          getPlantBedsWithPlants(params.id as string),
         ])
         setGarden(gardenData)
         setPlantBeds(plantBedsData)
@@ -188,7 +188,7 @@ export default function PlantBedsPage() {
                           )}
                         </div>
                       </div>
-                      <div className={`w-3 h-3 rounded-full border-2 ${bed.plants.length > 0 ? 'border-green-500 shadow-green-200' : 'border-gray-500 shadow-gray-200'}`}></div>
+                      <div className={`w-3 h-3 rounded-full border-2 ${(bed.plants?.length || 0) > 0 ? 'border-green-500 shadow-green-200' : 'border-gray-500 shadow-gray-200'}`}></div>
                     </div>
                     
                     <div className="space-y-2 text-sm text-gray-600 mb-4">
@@ -200,7 +200,7 @@ export default function PlantBedsPage() {
                       )}
                       <div className="flex justify-between">
                         <span>Planten:</span>
-                        <span>{bed.plants.length}</span>
+                        <span>{bed.plants?.length || 0}</span>
                       </div>
                       {bed.soil_type && (
                         <div className="flex justify-between">
@@ -220,15 +220,15 @@ export default function PlantBedsPage() {
                     </div>
 
                     {/* Show flower emojis preview */}
-                    {bed.plants.length > 0 && (
+                    {(bed.plants?.length || 0) > 0 && (
                       <div className="flex items-center gap-1 flex-wrap mb-4">
-                        {bed.plants.slice(0, 6).map((plant, index) => (
+                        {(bed.plants || []).slice(0, 6).map((plant, index) => (
                           <span key={index} className="text-lg" title={plant.name}>
                             {plant.emoji || '🌸'}
                           </span>
                         ))}
-                        {bed.plants.length > 6 && (
-                          <span className="text-xs text-gray-500 ml-1">+{bed.plants.length - 6}</span>
+                        {(bed.plants?.length || 0) > 6 && (
+                          <span className="text-xs text-gray-500 ml-1">+{(bed.plants?.length || 0) - 6}</span>
                         )}
                       </div>
                     )}
@@ -241,7 +241,7 @@ export default function PlantBedsPage() {
                       <div className="flex-1 min-w-0">
                         <h3 className="font-medium text-gray-900 truncate">{bed.name}</h3>
                         <div className="flex items-center gap-4 text-sm text-gray-600 mt-1">
-                          <span>{bed.plants.length} planten</span>
+                          <span>{bed.plants?.length || 0} planten</span>
                           {bed.size && <span>Grootte: {bed.size}</span>}
                           {bed.sun_exposure && (
                             <div className="flex items-center gap-1">
@@ -250,21 +250,21 @@ export default function PlantBedsPage() {
                             </div>
                           )}
                         </div>
-                        {bed.plants.length > 0 && (
+                        {(bed.plants?.length || 0) > 0 && (
                           <div className="flex items-center gap-1 mt-2">
-                            {bed.plants.slice(0, 4).map((plant, index) => (
+                            {(bed.plants || []).slice(0, 4).map((plant, index) => (
                               <span key={index} className="text-sm" title={plant.name}>
                                 {plant.emoji || '🌸'}
                               </span>
                             ))}
-                            {bed.plants.length > 4 && (
-                              <span className="text-xs text-gray-500 ml-1">+{bed.plants.length - 4}</span>
+                            {(bed.plants?.length || 0) > 4 && (
+                              <span className="text-xs text-gray-500 ml-1">+{(bed.plants?.length || 0) - 4}</span>
                             )}
                           </div>
                         )}
                       </div>
                     </div>
-                    <div className={`w-3 h-3 rounded-full border-2 ml-3 flex-shrink-0 ${bed.plants.length > 0 ? 'border-green-500 shadow-green-200' : 'border-gray-500 shadow-gray-200'}`}></div>
+                    <div className={`w-3 h-3 rounded-full border-2 ml-3 flex-shrink-0 ${(bed.plants?.length || 0) > 0 ? 'border-green-500 shadow-green-200' : 'border-gray-500 shadow-gray-200'}`}></div>
                   </div>
                 )}
 
@@ -357,7 +357,7 @@ export default function PlantBedsPage() {
               </div>
               <div>
                 <div className="text-2xl font-bold text-blue-600">
-                  {plantBeds.reduce((sum, bed) => sum + Math.max(1, bed.plants.length), 0)}
+                  {plantBeds.reduce((sum, bed) => sum + Math.max(1, bed.plants?.length || 0), 0)}
                 </div>
                 <div className="text-sm text-gray-600">Totaal Planten</div>
               </div>

--- a/app/logbook/[id]/edit/page.tsx
+++ b/app/logbook/[id]/edit/page.tsx
@@ -12,13 +12,13 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@
 import { useToast } from "@/hooks/use-toast"
 import { ArrowLeft, Save, Upload, X, Image as ImageIcon } from "lucide-react"
 import { LogbookService } from "@/lib/services/database.service"
-import { getPlantBeds } from "@/lib/database"
+import { getPlantBedsWithPlants } from "@/lib/database"
 import { uploadImage, type UploadResult } from "@/lib/storage"
-import type { LogbookEntryWithDetails, PlantvakWithPlants } from "@/lib/types/index"
+import type { LogbookEntryWithDetails, PlantBedWithPlants } from "@/lib/types/index"
 
 interface EditLogbookState {
   entry: LogbookEntryWithDetails | null
-  plantBeds: PlantvakWithPlants[]
+  plantBeds: PlantBedWithPlants[]
   loading: boolean
   saving: boolean
   error: string | null
@@ -72,7 +72,7 @@ export default function EditLogbookPage() {
         const entry = entryResponse.data
         
         // Load plant beds
-        const plantBeds = await getPlantBeds(entry.garden_id)
+        const plantBeds = await getPlantBedsWithPlants(entry.garden_id)
 
         // Set form data
         setFormData({
@@ -86,7 +86,7 @@ export default function EditLogbookPage() {
         setState(prev => ({
           ...prev,
           entry,
-          plantBeds: plantBeds as PlantvakWithPlants[],
+          plantBeds: plantBeds,
           loading: false,
         }))
 

--- a/app/logbook/new/page.tsx
+++ b/app/logbook/new/page.tsx
@@ -14,16 +14,16 @@ import { Textarea } from "@/components/ui/textarea"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { ArrowLeft, Calendar, Camera, Upload, X, Loader2 } from "lucide-react"
 import { LogbookService } from "@/lib/services/database.service"
-import { getPlantBeds, getPlantBed } from "@/lib/database"
+import { getPlantBedsWithPlants, getPlantBed } from "@/lib/database"
 import { uploadImage, type UploadResult } from "@/lib/storage"
 import { uiLogger } from "@/lib/logger"
-import type { LogbookEntryFormData, Plant, PlantvakWithPlants } from "@/lib/types/index"
+import type { LogbookEntryFormData, Plant, PlantBedWithPlants } from "@/lib/types/index"
 import { ErrorBoundary } from "@/components/error-boundary"
 import { useToast } from "@/hooks/use-toast"
 import { format } from "date-fns"
 
 interface NewLogbookPageState {
-  plantBeds: PlantvakWithPlants[]
+  plantBeds: PlantBedWithPlants[]
   plants: Plant[]
   loading: boolean
   submitting: boolean
@@ -62,7 +62,7 @@ function NewLogbookPageContent() {
       setState(prev => ({ ...prev, loading: true, error: null }))
       
       // Load plant beds
-      const plantBeds = await getPlantBeds(gardenId)
+      const plantBeds = await getPlantBedsWithPlants(gardenId)
 
       // Load plants if a plant bed is selected
       let plants: Plant[] = []
@@ -75,7 +75,7 @@ function NewLogbookPageContent() {
 
       setState(prev => ({
         ...prev,
-        plantBeds: (plantBeds || []) as PlantvakWithBloemen[],
+        plantBeds: plantBeds || [],
         plants,
         loading: false
       }))

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -15,9 +15,9 @@ import { Badge } from "@/components/ui/badge"
 import { Skeleton } from "@/components/ui/skeleton"
 import { TreePine, Plus, Search, MapPin, Calendar, Leaf, AlertCircle, Grid3X3 } from "lucide-react"
 import { TuinService } from "@/lib/services/database.service"
-import { getPlantBeds } from "@/lib/database"
+import { getPlantBedsWithPlants } from "@/lib/database"
 import { uiLogger, AuditLogger } from "@/lib/logger"
-import type { Tuin, PlantvakWithPlants } from "@/lib/types/index"
+import type { Tuin, PlantBedWithPlants } from "@/lib/types/index"
 import { ErrorBoundary } from "@/components/error-boundary"
 import { useToast } from "@/hooks/use-toast"
 import { useAuth } from "@/hooks/use-supabase-auth"
@@ -378,7 +378,7 @@ interface GardenCardProps {
 }
 
 function GardenCard({ garden, onDelete, isListView = false }: GardenCardProps) {
-  const [plantBeds, setPlantBeds] = React.useState<PlantvakWithPlants[]>([])
+  const [plantBeds, setPlantBeds] = React.useState<PlantBedWithPlants[]>([])
   const [loadingFlowers, setLoadingFlowers] = React.useState(true)
   const [gardenUsers, setGardenUsers] = React.useState<Array<{ id: string; email: string; full_name?: string }>>([])
   const [loadingUsers, setLoadingUsers] = React.useState(true)
@@ -422,8 +422,8 @@ function GardenCard({ garden, onDelete, isListView = false }: GardenCardProps) {
     const loadFlowers = async () => {
       try {
         setLoadingFlowers(true)
-        const beds = await getPlantBeds(garden.id)
-        setPlantBeds(beds as PlantvakWithPlants[])
+        const beds = await getPlantBedsWithPlants(garden.id)
+        setPlantBeds(beds)
       } catch (error) {
         uiLogger.error('Error loading flowers for garden preview', error as Error, { gardenId: garden.id })
         setPlantBeds([])


### PR DESCRIPTION
Fixes 'Cannot read properties of undefined (reading 'length')' by using `getPlantBedsWithPlants` and adding safe checks for plant bed data.

The error occurred because UI components expected plant bed data to include a `plants` array (type `PlantBedWithPlants`), but the `getPlantBeds` function only returned basic `PlantBed` objects without the `plants` relation. Switching to `getPlantBedsWithPlants` ensures the necessary data is fetched, and additional nullish coalescing operators (`?.length || 0`, `|| []`) prevent errors if `plants` is still unexpectedly undefined.

---
<a href="https://cursor.com/background-agent?bcId=bc-6e31dfd2-3a34-4e58-b60f-1837c912d411">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6e31dfd2-3a34-4e58-b60f-1837c912d411">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

