### PR TITLE
test: add theme and language switcher tests

### DIFF
--- a/__tests__/components/language-switcher.test.tsx
+++ b/__tests__/components/language-switcher.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { vi } from 'vitest'
+import { LanguageSwitcher } from '@/components/language-switcher'
+
+let language = 'nl'
+const setLanguage = vi.fn((newLang: string) => {
+  language = newLang
+})
+
+vi.mock('@/hooks/use-language', () => ({
+  useLanguage: () => ({ language, setLanguage })
+}))
+
+describe('LanguageSwitcher', () => {
+  beforeEach(() => {
+    language = 'nl'
+    setLanguage.mockClear()
+  })
+
+  it('renders and toggles language on click', () => {
+    const { rerender } = render(<LanguageSwitcher />)
+
+    const button = screen.getByRole('button')
+    expect(button).toHaveTextContent('EN')
+
+    fireEvent.click(button)
+    expect(setLanguage).toHaveBeenCalledWith('en')
+
+    rerender(<LanguageSwitcher />)
+    const buttonAfter = screen.getByRole('button')
+    expect(buttonAfter).toHaveTextContent('NL')
+
+    fireEvent.click(buttonAfter)
+    expect(setLanguage).toHaveBeenLastCalledWith('nl')
+  })
+})

--- a/__tests__/components/theme-toggle.test.tsx
+++ b/__tests__/components/theme-toggle.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { vi } from 'vitest'
+import { ThemeToggle } from '@/components/theme-toggle'
+
+let theme = 'light'
+const setTheme = vi.fn((newTheme: string) => {
+  theme = newTheme
+})
+
+vi.mock('next-themes', () => ({
+  useTheme: () => ({ theme, systemTheme: 'light', setTheme })
+}))
+
+describe('ThemeToggle', () => {
+  beforeEach(() => {
+    theme = 'light'
+    setTheme.mockClear()
+  })
+
+  it('renders current theme', async () => {
+    render(<ThemeToggle />)
+
+    await waitFor(() => expect(screen.getByRole('button')).not.toBeDisabled())
+
+    expect(screen.getByRole('button')).toHaveAttribute(
+      'aria-label',
+      'Huidige thema: Licht. Klik om te wijzigen.'
+    )
+  })
+
+  it('changes theme when selecting option', async () => {
+    const { rerender } = render(<ThemeToggle />)
+
+    await waitFor(() => expect(screen.getByRole('button')).not.toBeDisabled())
+
+    fireEvent.click(screen.getByRole('button'))
+    fireEvent.click(screen.getByText('Donker'))
+
+    expect(setTheme).toHaveBeenCalledWith('dark')
+
+    rerender(<ThemeToggle />)
+
+    await waitFor(() =>
+      expect(screen.getByRole('button')).toHaveAttribute(
+        'aria-label',
+        'Huidige thema: Donker. Klik om te wijzigen.'
+      )
+    )
+  })
+})


### PR DESCRIPTION
## Summary
- add tests for ThemeToggle component
- add tests for LanguageSwitcher component

## Testing
- `npm run test:coverage` *(fails: 355 failing tests in existing suite)*

------
https://chatgpt.com/codex/tasks/task_e_68a753d9eae88326be63b647a27b9c7a