### PR TITLE
Add unit tests for navigation hook

### DIFF
--- a/__tests__/hooks/use-navigation.test.ts
+++ b/__tests__/hooks/use-navigation.test.ts
@@ -1,0 +1,73 @@
+import { renderHook, act } from '@testing-library/react'
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { useNavigation } from '@/hooks/use-navigation'
+import { useRouter } from 'next/navigation'
+
+let push: ReturnType<typeof vi.fn>
+let replace: ReturnType<typeof vi.fn>
+
+describe('useNavigation', () => {
+  beforeEach(() => {
+    push = vi.fn()
+    replace = vi.fn()
+    vi.mocked(useRouter).mockReturnValue({
+      push,
+      replace,
+    } as any)
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    // reset history length to default
+    Object.defineProperty(window.history, 'length', { configurable: true, value: 1 })
+    vi.restoreAllMocks()
+  })
+
+  it('uses browser history when available', () => {
+    const backSpy = vi.spyOn(window.history, 'back').mockImplementation(() => {})
+    Object.defineProperty(window.history, 'length', { configurable: true, value: 2 })
+
+    const { result } = renderHook(() => useNavigation())
+
+    act(() => {
+      result.current.goBack()
+    })
+
+    expect(backSpy).toHaveBeenCalledTimes(1)
+    expect(push).not.toHaveBeenCalled()
+  })
+
+  it('falls back to router.push when history is unavailable', () => {
+    const backSpy = vi.spyOn(window.history, 'back').mockImplementation(() => {})
+    Object.defineProperty(window.history, 'length', { configurable: true, value: 1 })
+
+    const { result } = renderHook(() => useNavigation())
+
+    act(() => {
+      result.current.goBack()
+    })
+
+    expect(backSpy).not.toHaveBeenCalled()
+    expect(push).toHaveBeenCalledWith('/')
+  })
+
+  it('navigateTo calls router.push with correct path', () => {
+    const { result } = renderHook(() => useNavigation())
+
+    act(() => {
+      result.current.navigateTo('/test')
+    })
+
+    expect(push).toHaveBeenCalledWith('/test')
+  })
+
+  it('replace calls router.replace with correct path', () => {
+    const { result } = renderHook(() => useNavigation())
+
+    act(() => {
+      result.current.replace('/new')
+    })
+
+    expect(replace).toHaveBeenCalledWith('/new')
+  })
+})


### PR DESCRIPTION
## Summary
- add tests for useNavigation hook covering goBack, navigateTo, and replace

## Testing
- `npm run test:coverage` *(fails: Cannot find module '@/lib/supabase')*
- `npx vitest run __tests__/hooks/use-navigation.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68a753ec35cc832696a04030914ea1c0