### PR TITLE
Check code review again with fallback

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -79,16 +79,62 @@ jobs:
           head -c 120000 codeql-alerts.json
         } > codeql-openai-prompt.txt
 
-    - name: Call OpenAI to generate Code Quality summary
+    - name: Generate AI Code Quality summary (with fallback)
       id: openai
       env:
         OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       run: |
+        set -e
+
+        generate_fallback() {
+          {
+            echo "# AI Code Quality Summary (Fallback)";
+            echo;
+            echo "OpenAI is not configured or failed. This is an automated summary generated directly from CodeQL alerts.";
+            echo;
+            echo "## Status";
+            echo "- Total alerts: $(jq 'length' codeql-alerts.json 2>/dev/null || echo 0)";
+            echo;
+            echo "## Alerts by severity";
+            jq -r '
+              (sort_by(.rule.severity // "unknown")
+               | group_by(.rule.severity // "unknown")
+               | map({severity: (.[0].rule.severity // "unknown"), count: length})) as $groups
+              | if ($groups | length) == 0 then "- none"
+                else $groups[] | "- \(.severity): \(.count)"
+                end
+            ' codeql-alerts.json 2>/dev/null || echo "- none";
+            echo;
+            echo "## Top files with alerts";
+            jq -r '
+              [ group_by(.most_recent_instance.location.path // "unknown")[]
+                | { path: (.[0].most_recent_instance.location.path // "unknown"), count: length } ]
+              | sort_by(.count) | reverse | .[:10]
+              | if length==0 then "- none"
+                else .[] | "- " + .path + ": " + (.count|tostring) + " alerts"
+                end
+            ' codeql-alerts.json 2>/dev/null || echo "- none";
+            echo;
+            echo "## Sample alerts";
+            jq -r '
+              .[:10]
+              | if length==0 then "No alerts."
+                else .[] | "- [" + ((.rule.severity // "unknown")|tostring) + "] "
+                             + (.rule.id // "unknown") + " — "
+                             + ((.most_recent_instance.location.path // "unknown") + ":" + ((.most_recent_instance.location.start_line // 0)|tostring))
+                end
+            ' codeql-alerts.json 2>/dev/null || echo "No alerts.";
+          } > ai-code-quality-summary.md
+        }
+
+        # If no key, generate fallback summary
         if [ -z "$OPENAI_API_KEY" ]; then
-          echo "OPENAI_API_KEY not set; writing fallback summary";
-          echo "# AI Code Quality Summary\n\nOpenAI key not configured. Please set repository secret OPENAI_API_KEY." > ai-code-quality-summary.md
+          echo "OPENAI_API_KEY not set; generating fallback summary";
+          generate_fallback
           exit 0
         fi
+
+        # Build payload for OpenAI
         PAYLOAD=$(jq -n \
           --arg content "$(< codeql-openai-prompt.txt)" \
           '{
@@ -99,12 +145,25 @@ jobs:
               {role:"user", content:$content}
             ]
           }')
-        curl -sS https://api.openai.com/v1/chat/completions \
+
+        # Call OpenAI; if it fails, fallback
+        if ! curl -sS https://api.openai.com/v1/chat/completions \
           -H "Authorization: Bearer $OPENAI_API_KEY" \
           -H "Content-Type: application/json" \
           --data "$PAYLOAD" \
-          -o openai.out.json
-        jq -r '.choices[0].message.content // "No content returned by OpenAI."' openai.out.json > ai-code-quality-summary.md
+          -o openai.out.json; then
+          echo "OpenAI request failed; generating fallback summary";
+          generate_fallback
+          exit 0
+        fi
+
+        CONTENT=$(jq -r '.choices[0].message.content // empty' openai.out.json 2>/dev/null || true)
+        if [ -z "$CONTENT" ]; then
+          echo "OpenAI response empty; generating fallback summary";
+          generate_fallback
+        else
+          echo "$CONTENT" > ai-code-quality-summary.md
+        fi
 
     - name: Upload CodeQL AI summary artifact
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
Add a robust fallback to the CodeQL workflow's AI summary generation for when OpenAI is unavailable.

The previous implementation would fail to generate any summary if the `OPENAI_API_KEY` was not set or if the OpenAI API call failed. This PR ensures that a useful Markdown summary, derived directly from the CodeQL alerts JSON, is always provided, detailing alerts by severity, top files, and sample alerts.

---
<a href="https://cursor.com/background-agent?bcId=bc-b8b60f9a-88b1-48e8-81f7-ded51d86655f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b8b60f9a-88b1-48e8-81f7-ded51d86655f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

