### PR TITLE
Run traditional banking tests and report coverage

### DIFF
--- a/.github/workflows/banking-tests.yml
+++ b/.github/workflows/banking-tests.yml
@@ -479,9 +479,11 @@ jobs:
           script: |
             const fs = require('fs');
             
-            // Try to read the enhanced test report first
+            // Prefer enriched report from our runner
             let reportContent = '';
-            if (fs.existsSync('test-results/detailed-report.md')) {
+            if (fs.existsSync('test-results/test-report.md')) {
+              reportContent = fs.readFileSync('test-results/test-report.md', 'utf8');
+            } else if (fs.existsSync('test-results/detailed-report.md')) {
               reportContent = fs.readFileSync('test-results/detailed-report.md', 'utf8');
             } else if (fs.existsSync('test-summary.md')) {
               reportContent = fs.readFileSync('test-summary.md', 'utf8');

--- a/.github/workflows/banking-tests.yml
+++ b/.github/workflows/banking-tests.yml
@@ -479,12 +479,14 @@ jobs:
           script: |
             const fs = require('fs');
             
-            // Prefer enriched report from our runner
+            // Prefer enriched report from artifacts (runner output)
             let reportContent = '';
-            if (fs.existsSync('test-results/test-report.md')) {
+            if (fs.existsSync('test-artifacts/test-results/test-report.md')) {
+              reportContent = fs.readFileSync('test-artifacts/test-results/test-report.md', 'utf8');
+            } else if (fs.existsSync('test-results/test-report.md')) {
               reportContent = fs.readFileSync('test-results/test-report.md', 'utf8');
-            } else if (fs.existsSync('test-results/detailed-report.md')) {
-              reportContent = fs.readFileSync('test-results/detailed-report.md', 'utf8');
+            } else if (fs.existsSync('test-artifacts/test-results/detailed-report.md')) {
+              reportContent = fs.readFileSync('test-artifacts/test-results/detailed-report.md', 'utf8');
             } else if (fs.existsSync('test-summary.md')) {
               reportContent = fs.readFileSync('test-summary.md', 'utf8');
             } else {

--- a/.github/workflows/banking-tests.yml
+++ b/.github/workflows/banking-tests.yml
@@ -486,6 +486,8 @@ jobs:
             } else if (fs.existsSync('test-results/test-report.md')) {
               // Fallback when artifact aggregation step did not run
               reportContent = fs.readFileSync('test-results/test-report.md', 'utf8');
+            } else if (fs.existsSync('test-artifacts/test-results/detailed-report.md')) {
+              reportContent = fs.readFileSync('test-artifacts/test-results/detailed-report.md', 'utf8');
             } else if (fs.existsSync('test-artifacts/test-results/all-tests.xml')) {
               // As last resort, generate a minimal summary directly from JUnit
               const xml = fs.readFileSync('test-artifacts/test-results/all-tests.xml', 'utf8');
@@ -494,9 +496,6 @@ jobs:
                 const tests = header[1], fails = header[2], errs = header[3], secs = header[4];
                 reportContent = `# 🏦 Traditional Banking System Test Report\n\n**Total Tests**: ${tests}\n**Failed**: ${fails}\n**Errors**: ${errs}\n**Duration**: ${parseFloat(secs).toFixed(2)}s\n\n<!-- TRADITIONAL_BANKING_TEST_REPORT -->`;
               }
-            }
-            } else if (fs.existsSync('test-artifacts/test-results/detailed-report.md')) {
-              reportContent = fs.readFileSync('test-artifacts/test-results/detailed-report.md', 'utf8');
             } else if (fs.existsSync('test-summary.md')) {
               reportContent = fs.readFileSync('test-summary.md', 'utf8');
             } else {

--- a/.github/workflows/banking-tests.yml
+++ b/.github/workflows/banking-tests.yml
@@ -484,7 +484,17 @@ jobs:
             if (fs.existsSync('test-artifacts/test-results/test-report.md')) {
               reportContent = fs.readFileSync('test-artifacts/test-results/test-report.md', 'utf8');
             } else if (fs.existsSync('test-results/test-report.md')) {
+              // Fallback when artifact aggregation step did not run
               reportContent = fs.readFileSync('test-results/test-report.md', 'utf8');
+            } else if (fs.existsSync('test-artifacts/test-results/all-tests.xml')) {
+              // As last resort, generate a minimal summary directly from JUnit
+              const xml = fs.readFileSync('test-artifacts/test-results/all-tests.xml', 'utf8');
+              const header = xml.match(/<testsuites[^>]*tests=\"(\\d+)\"[^>]*failures=\"(\\d+)\"[^>]*errors=\"(\\d+)\"[^>]*time=\"([^\"]+)\"/);
+              if (header) {
+                const tests = header[1], fails = header[2], errs = header[3], secs = header[4];
+                reportContent = `# 🏦 Traditional Banking System Test Report\n\n**Total Tests**: ${tests}\n**Failed**: ${fails}\n**Errors**: ${errs}\n**Duration**: ${parseFloat(secs).toFixed(2)}s\n\n<!-- TRADITIONAL_BANKING_TEST_REPORT -->`;
+              }
+            }
             } else if (fs.existsSync('test-artifacts/test-results/detailed-report.md')) {
               reportContent = fs.readFileSync('test-artifacts/test-results/detailed-report.md', 'utf8');
             } else if (fs.existsSync('test-summary.md')) {

--- a/.github/workflows/banking-tests.yml
+++ b/.github/workflows/banking-tests.yml
@@ -491,6 +491,11 @@ jobs:
               reportContent = '## 🧪 Test Execution Summary\n\n⚠️ Detailed test report not available. Check the workflow logs for more information.';
             }
             
+            const marker = '<!-- TRADITIONAL_BANKING_TEST_REPORT -->';
+            if (!reportContent.includes(marker)) {
+              reportContent += `\n\n${marker}`;
+            }
+            
             // Find existing test report comment and update it, or create new one
             const { data: comments } = await github.rest.issues.listComments({
               issue_number: context.issue.number,
@@ -500,7 +505,7 @@ jobs:
             
             const existingComment = comments.find(comment => 
               comment.user.type === 'Bot' && 
-              (comment.body.includes('PROFESSIONAL TEST REPORT') || comment.body.includes('Test Execution Summary'))
+              comment.body.includes('<!-- TRADITIONAL_BANKING_TEST_REPORT -->')
             );
             
             if (existingComment) {

--- a/.github/workflows/banking-tests.yml
+++ b/.github/workflows/banking-tests.yml
@@ -207,6 +207,11 @@ jobs:
           echo "" >> test-results/pipeline-summary.md
           echo "**Note**: Check the detailed test analysis report for complete breakdown." >> test-results/pipeline-summary.md
 
+      - name: Generate enriched markdown report (JUnit + Top Failures)
+        run: |
+          # Produce test-results/test-report.md + test-results/ci.xml using our enhanced runner
+          node scripts/run-banking-tests.js --ci --report || true
+
       - name: Generate test summary
         run: |
           echo "Generating test execution summary..."
@@ -365,7 +370,7 @@ jobs:
               # Show high priority failures
               if [ "$high_priority" -gt 0 ]; then
                 echo "### ⚠️ High Priority Failures (Binnen 1 Week)" >> test-summary.md
-                jq -r '.recommendations.high[] | "- " + .name + ": " + .failures + " failures (" + (.successRate | tostring) + "% success)"' test-artifacts/test-analysis-fixed-summary.json
+                jq -r '.recommendations.high[] | "- " + .name + ": " + (.failures|tostring) + " failures (" + ((.successRate*100|floor)/100|tostring) + "% success)"' test-artifacts/test-analysis-fixed-summary.json >> test-summary.md
                 echo "" >> test-summary.md
               fi
               

--- a/scripts/run-banking-tests.js
+++ b/scripts/run-banking-tests.js
@@ -213,6 +213,22 @@ function readCoverageSummaryIfAny() {
   return null;
 }
 
+function resolveJUnitPath() {
+  try {
+    const preferred = path.join(CONFIG.testResultsDir, 'ci.xml');
+    if (fs.existsSync(preferred)) return preferred;
+    const fallback = path.join(CONFIG.testResultsDir, 'all-tests.xml');
+    if (fs.existsSync(fallback)) return fallback;
+    if (fs.existsSync(CONFIG.testResultsDir)) {
+      const files = fs.readdirSync(CONFIG.testResultsDir)
+        .filter(f => f.toLowerCase().endsWith('.xml'))
+        .map(f => path.join(CONFIG.testResultsDir, f));
+      if (files.length > 0) return files[0];
+    }
+  } catch (_) {}
+  return path.join(CONFIG.testResultsDir, 'ci.xml');
+}
+
 async function runTestSuite(suite) {
   log(`Starting ${suite.name} tests...`);
   
@@ -275,7 +291,7 @@ function generateTestReport(results) {
     suites: results,
     coverage: null,
     artifacts: {
-      junit: path.join(CONFIG.testResultsDir, 'ci.xml'),
+      junit: resolveJUnitPath(),
       coverageDir: CONFIG.coverageDir
     },
     junit: null,


### PR DESCRIPTION
Add detailed numeric test results and "Top Failures" sections to the banking test report by parsing JUnit and coverage artifacts.

The original report was a static template. This PR integrates dynamic parsing of `ci.xml` (JUnit) and `coverage-summary.json` to populate the report with actual test counts, pass rates, and categorized lists of failing test suites, making the report actionable.

---
<a href="https://cursor.com/background-agent?bcId=bc-6a83fe6f-52b8-4e87-bfdb-6b3a4b30b525">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6a83fe6f-52b8-4e87-bfdb-6b3a4b30b525">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

