### PR TITLE
Analyseer en los paginafouten op

### DIFF
--- a/app/agenda/page.tsx
+++ b/app/agenda/page.tsx
@@ -1,0 +1,33 @@
+"use client"
+
+import Link from "next/link"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Calendar, ArrowLeft } from "lucide-react"
+
+export default function AgendaPage() {
+	return (
+		<div className="container mx-auto px-4 py-8 max-w-3xl">
+			<Button asChild variant="ghost" className="mb-6">
+				<Link href="/">
+					<ArrowLeft className="h-4 w-4 mr-2" />
+					Terug naar Home
+				</Link>
+			</Button>
+
+			<Card>
+				<CardHeader>
+					<CardTitle className="flex items-center gap-2">
+						<Calendar className="h-5 w-5 text-green-600" />
+						Agenda
+					</CardTitle>
+				</CardHeader>
+				<CardContent>
+					<p className="text-muted-foreground">
+						De agenda-functionaliteit komt hier beschikbaar. Voor nu: bekijk en beheer taken op de pagina Taken.
+					</p>
+				</CardContent>
+			</Card>
+		</div>
+	)
+}

--- a/app/api/admin/trash/route.ts
+++ b/app/api/admin/trash/route.ts
@@ -1,8 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { getSupabaseAdminClient } from '@/lib/supabase'
 
-// Force dynamic rendering since this route handles query parameters
 export const dynamic = 'force-dynamic'
+export const runtime = 'nodejs'
 
 function localAuditLog(action: string, details: Record<string, unknown>) {
   // Use structured logging instead of console.log for production

--- a/app/api/admin/users/route.ts
+++ b/app/api/admin/users/route.ts
@@ -3,6 +3,7 @@ import { getSupabaseAdminClient } from '@/lib/supabase'
 
 // Force dynamic rendering since this route handles query parameters
 export const dynamic = 'force-dynamic';
+export const runtime = 'nodejs'
 
 // Secure password generator
 function generateSecurePassword(): string {

--- a/app/gardens/[id]/page.tsx
+++ b/app/gardens/[id]/page.tsx
@@ -40,6 +40,7 @@ import {
   parsePlantBedDimensions
 } from "@/lib/scaling-constants"
 import { FlowerVisualization } from "@/components/flower-visualization"
+import { useSearchParams } from "next/navigation"
 
 // PlantBedPosition interface removed - not used in simplified version
 
@@ -47,6 +48,7 @@ export default function GardenDetailPage() {
   const { goBack, navigateTo } = useNavigation()
   const { isVisualView, toggleView } = useViewPreference()
   const params = useParams()
+  const searchParams = useSearchParams()
   const [garden, setGarden] = useState<Garden | null>(null)
   const [plantBeds, setPlantBeds] = useState<PlantBedWithPlants[]>([])
   const [loading, setLoading] = useState(true)
@@ -193,6 +195,12 @@ export default function GardenDetailPage() {
         }))
         
         setPlantBeds(processedBeds)
+
+        // Apply selection from query param if present
+        const initialBedId = searchParams?.get('bedId')
+        if (initialBedId) {
+          setSelectedBed(initialBedId)
+        }
       } catch (error) {
         console.error("Error loading data:", error)
         setGarden(null)
@@ -205,7 +213,7 @@ export default function GardenDetailPage() {
     if (params.id) {
       loadData()
     }
-  }, [params.id])
+  }, [params.id, searchParams])
 
   // Convert dimensions from string (e.g., "2m x 1.5m" or "2 x 1.5") to pixels
   const getDimensionsFromSize = (size: string) => {
@@ -691,7 +699,7 @@ export default function GardenDetailPage() {
                           transformOrigin: 'center center',
                         }}
                         onClick={() => setSelectedBed(bed.id)}
-                        onDoubleClick={() => navigateTo(`/gardens/${garden?.id}/plantvak-view/${bed.id}`)}
+                        onDoubleClick={() => navigateTo(`/gardens/${garden?.id}?bedId=${bed.id}`)}
                       >
                         <div className={`w-full h-full rounded-lg bg-green-50 border border-gray-200 group-hover:bg-green-100 transition-colors relative ${
                           isSelected ? 'bg-blue-100 border-blue-300' : ''

--- a/app/gardens/[id]/plant-beds/[bedId]/plants/[plantId]/edit/page.tsx
+++ b/app/gardens/[id]/plant-beds/[bedId]/plants/[plantId]/edit/page.tsx
@@ -194,7 +194,7 @@ export default function EditPlantPage() {
         description: `Plant "${plantData.name}" is succesvol bijgewerkt.`,
       })
 
-      router.push(`/gardens/${params.id}/plantvak-view/${params.bedId}`)
+      router.push(`/gardens/${params.id}?bedId=${params.bedId}`)
     } catch (error) {
       // Console logging removed for banking standards.error('Error updating plant:', error)
       toast({
@@ -224,7 +224,7 @@ export default function EditPlantPage() {
         description: `Plant "${plant.name}" is succesvol verwijderd.`,
       })
 
-      router.push(`/gardens/${params.id}/plantvak-view/${params.bedId}`)
+      router.push(`/gardens/${params.id}?bedId=${params.bedId}`)
     } catch (error) {
       // Console logging removed for banking standards.error('Error deleting plant:', error)
       toast({
@@ -277,7 +277,7 @@ export default function EditPlantPage() {
           <h2 className="text-2xl font-bold text-gray-900 mb-4">Plant niet gevonden</h2>
           <p className="text-gray-600 mb-6">De opgevraagde plant bestaat niet of is verwijderd.</p>
           <Button asChild>
-            <Link href={`/gardens/${params.id}/plantvak-view/${params.bedId}`}>
+            <Link href={`/gardens/${params.id}?bedId=${params.bedId}`}>
               <ArrowLeft className="h-4 w-4 mr-2" />
               Terug naar plantvak
             </Link>
@@ -291,7 +291,7 @@ export default function EditPlantPage() {
     <div className="container mx-auto p-6 max-w-4xl">
       {/* Back button */}
       <Button asChild variant="ghost" className="mb-6">
-        <Link href={`/gardens/${params.id}/plantvak-view/${params.bedId}`}>
+        <Link href={`/gardens/${params.id}?bedId=${params.bedId}`}>
           <ArrowLeft className="h-4 w-4 mr-2" />
           Terug naar plantvak
         </Link>

--- a/app/gardens/[id]/plant-beds/[bedId]/plants/new/page.tsx
+++ b/app/gardens/[id]/plant-beds/[bedId]/plants/new/page.tsx
@@ -176,7 +176,7 @@ export default function NewPlantPage() {
         description: `Plant "${plantData.name}" is succesvol toegevoegd aan ${plantBed.name}.`,
       })
       
-      router.push(`/gardens/${garden?.id}/plantvak-view/${plantBed.id}`)
+      router.push(`/gardens/${garden?.id}?bedId=${plantBed.id}`)
     } catch (error) {
       // Console logging removed for banking standards.error('Error creating plant:', error)
       toast({
@@ -230,7 +230,7 @@ export default function NewPlantPage() {
     <div className="container mx-auto p-6 max-w-4xl">
       {/* Back button */}
       <Button asChild variant="ghost" className="mb-6">
-        <Link href={`/gardens/${garden.id}/plantvak-view/${plantBed.id}`}>
+        <Link href={`/gardens/${garden.id}?bedId=${plantBed.id}`}>
           <ArrowLeft className="h-4 w-4 mr-2" />
           Terug naar plantvak
         </Link>

--- a/app/gardens/[id]/plant-beds/[bedId]/plants/page.tsx
+++ b/app/gardens/[id]/plant-beds/[bedId]/plants/page.tsx
@@ -8,8 +8,10 @@ export default function PlantBedPlantsRedirectPage() {
   const router = useRouter()
 
   useEffect(() => {
-    // Redirect to the visual plantvak-view instead of showing a list
-    router.replace(`/gardens/${params.id}/plantvak-view/${params.bedId}`)
+    // Redirect to the garden page with selected bed via query param
+    if (params.id && params.bedId) {
+      router.replace(`/gardens/${params.id}?bedId=${params.bedId}`)
+    }
   }, [params.id, params.bedId, router])
 
   // Show loading while redirecting

--- a/app/gardens/[id]/plantvak-view/page.tsx
+++ b/app/gardens/[id]/plantvak-view/page.tsx
@@ -1,20 +1,23 @@
 "use client"
 
 import { useEffect } from "react"
-import { useRouter, useParams } from "next/navigation"
+import { useRouter, useParams, useSearchParams } from "next/navigation"
 import { Card, CardContent } from "@/components/ui/card"
 import { Leaf } from "lucide-react"
 
 export default function PlantvakViewRedirectPage() {
   const router = useRouter()
   const params = useParams()
+  const searchParams = useSearchParams()
 
   useEffect(() => {
     // Redirect to the garden page since this route is deprecated
     if (params.id) {
-      router.replace(`/gardens/${params.id}`)
+      const bedId = searchParams?.get('bedId')
+      const target = bedId ? `/gardens/${params.id}?bedId=${bedId}` : `/gardens/${params.id}`
+      router.replace(target)
     }
-  }, [router, params.id])
+  }, [router, params.id, searchParams])
 
   return (
     <div className="container mx-auto p-6">

--- a/app/plants/new/page.tsx
+++ b/app/plants/new/page.tsx
@@ -1,0 +1,33 @@
+"use client"
+
+import Link from "next/link"
+import { Button } from "@/components/ui/button"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { Leaf, ArrowLeft } from "lucide-react"
+
+export default function NewPlantPage() {
+	return (
+		<div className="container mx-auto px-4 py-8 max-w-2xl">
+			<Button asChild variant="ghost" className="mb-6">
+				<Link href="/plants">
+					<ArrowLeft className="h-4 w-4 mr-2" />
+					Terug naar Planten
+				</Link>
+			</Button>
+
+			<Card>
+				<CardHeader>
+					<CardTitle className="flex items-center gap-2">
+						<Leaf className="h-5 w-5 text-green-600" />
+						Nieuwe Plant
+					</CardTitle>
+				</CardHeader>
+				<CardContent>
+					<p className="text-muted-foreground">
+						Deze pagina is nog in ontwikkeling. Voeg voorlopig planten toe via een plantvak.
+					</p>
+				</CardContent>
+			</Card>
+		</div>
+	)
+}


### PR DESCRIPTION
Refactor plantvak routing, add missing pages, and stabilize admin API runtime to resolve "unreachable" page issues.

The `plantvak-view` route caused navigation loops, and `/agenda` and `/plants/new` were missing, leading to 404s. Additionally, admin API routes needed `nodejs` runtime for consistent `SUPABASE_SERVICE_ROLE_KEY` access on Vercel preview environments. These changes provide structural fixes for page accessibility.

---
<a href="https://cursor.com/background-agent?bcId=bc-ea3e5d29-225a-4e5e-a658-db88d8d5d22b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ea3e5d29-225a-4e5e-a658-db88d8d5d22b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

