### PR TITLE
Fix white screens in dark mode

### DIFF
--- a/app/gardens/[id]/page.tsx
+++ b/app/gardens/[id]/page.tsx
@@ -1765,7 +1765,7 @@ export default function GardenDetailPage() {
           
           <div className="space-y-4">
             <div>
-              <label htmlFor="plantvak-name" className="block text-sm font-medium text-gray-700 mb-1">
+              <label htmlFor="plantvak-name" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
                 Plantvak Naam *
               </label>
               <Input
@@ -1778,7 +1778,7 @@ export default function GardenDetailPage() {
 
             <div className="grid grid-cols-2 gap-4">
               <div>
-                <label htmlFor="plantvak-length" className="block text-sm font-medium text-gray-700 mb-1">
+                <label htmlFor="plantvak-length" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
                   Lengte (m) *
                 </label>
                 <Input
@@ -1792,7 +1792,7 @@ export default function GardenDetailPage() {
                 />
               </div>
               <div>
-                <label htmlFor="plantvak-width" className="block text-sm font-medium text-gray-700 mb-1">
+                <label htmlFor="plantvak-width" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
                   Breedte (m) *
                 </label>
                 <Input
@@ -1808,13 +1808,13 @@ export default function GardenDetailPage() {
             </div>
 
             {newPlantBed.length && newPlantBed.width && (
-              <div className="text-sm text-green-600 font-medium">
+              <div className="text-sm text-green-600 dark:text-green-400 font-medium">
                 📐 Oppervlakte: {(parseFloat(newPlantBed.length) * parseFloat(newPlantBed.width)).toFixed(1)} m²
               </div>
             )}
 
             <div>
-              <label htmlFor="plantvak-sun" className="block text-sm font-medium text-gray-700 mb-1">
+              <label htmlFor="plantvak-sun" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
                 Zonligging
               </label>
               <Select value={newPlantBed.sun_exposure} onValueChange={(value: 'full-sun' | 'partial-sun' | 'shade') => 
@@ -1826,19 +1826,19 @@ export default function GardenDetailPage() {
                 <SelectContent>
                   <SelectItem value="full-sun">
                     <div className="flex items-center gap-2">
-                      <Sun className="h-4 w-4 text-yellow-500" />
+                      <Sun className="h-4 w-4 text-yellow-500 dark:text-yellow-400" />
                       <span>Volle zon</span>
                     </div>
                   </SelectItem>
                   <SelectItem value="partial-sun">
                     <div className="flex items-center gap-2">
-                      <CloudSun className="h-4 w-4 text-yellow-400" />
+                      <CloudSun className="h-4 w-4 text-yellow-400 dark:text-yellow-300" />
                       <span>Gedeeltelijke zon</span>
                     </div>
                   </SelectItem>
                   <SelectItem value="shade">
                     <div className="flex items-center gap-2">
-                      <Cloud className="h-4 w-4 text-gray-500" />
+                      <Cloud className="h-4 w-4 text-gray-500 dark:text-gray-400" />
                       <span>Schaduw</span>
                     </div>
                   </SelectItem>
@@ -1847,7 +1847,7 @@ export default function GardenDetailPage() {
             </div>
 
             <div>
-              <label htmlFor="plantvak-description" className="block text-sm font-medium text-gray-700 mb-1">
+              <label htmlFor="plantvak-description" className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
                 Beschrijving (optioneel)
               </label>
               <Textarea

--- a/app/gardens/[id]/plantvak-view/[bedId]/page.tsx
+++ b/app/gardens/[id]/plantvak-view/[bedId]/page.tsx
@@ -2030,9 +2030,9 @@ export default function PlantBedViewPage() {
           {viewMode === 'visual' ? (
             <>
               {/* Mobile help text */}
-              <div className="mb-4 p-3 bg-blue-50 border border-blue-200 rounded-lg md:hidden">
-                <h4 className="font-medium text-blue-900 mb-1">📱 Mobiele bediening:</h4>
-                <ul className="text-sm text-blue-800 space-y-1">
+              <div className="mb-4 p-3 bg-blue-50 dark:bg-blue-950/30 border border-blue-200 dark:border-blue-700 rounded-lg md:hidden">
+                <h4 className="font-medium text-blue-900 dark:text-blue-200 mb-1">📱 Mobiele bediening:</h4>
+                <ul className="text-sm text-blue-800 dark:text-blue-300 space-y-1">
                   <li>• <strong>1x tikken:</strong> Bloem selecteren</li>
                   <li>• <strong>2x tikken:</strong> Verplaatsen activeren</li>
                   <li>• <strong>3x tikken:</strong> Grootte aanpassen</li>
@@ -2040,18 +2040,18 @@ export default function PlantBedViewPage() {
                   <li>• <strong>Dubbel tikken:</strong> Grootte aanpassen (+ / -)</li>
                   <li>• <strong>Knoppen:</strong> Gebruik knoppen hierboven</li>
                 </ul>
-                <div className="mt-2 pt-2 border-t border-blue-300">
-                  <p className="text-xs text-blue-700">
+                <div className="mt-2 pt-2 border-t border-blue-300 dark:border-blue-600">
+                  <p className="text-xs text-blue-700 dark:text-blue-300">
                     🌱 <strong>Plantvak:</strong> {plantBed?.size || 'Onbekend'}
                   </p>
                 </div>
               </div>
               
               {/* Visual Canvas View */}
-              <div className="relative overflow-hidden rounded-lg border-2 border-dashed border-green-200">
+              <div className="relative overflow-hidden rounded-lg border-2 border-dashed border-green-200 dark:border-green-700">
             <div
               ref={containerRef}
-              className="relative bg-gradient-to-br from-green-50 via-emerald-50 to-green-100"
+              className="relative bg-gradient-to-br from-green-50 via-emerald-50 to-green-100 dark:from-green-950/30 dark:via-emerald-950/30 dark:to-green-900/30"
               style={{
                 width: getCanvasSize().width,
                 height: getCanvasSize().height,
@@ -2096,7 +2096,7 @@ export default function PlantBedViewPage() {
                 
                 return (
                   <div
-                    className="absolute border-2 border-dashed border-green-400 bg-green-50/20 rounded-lg pointer-events-none"
+                    className="absolute border-2 border-dashed border-green-400 dark:border-green-600 bg-green-50/20 dark:bg-green-950/30 rounded-lg pointer-events-none"
                     style={{
                       left: plantvakStartX,
                       top: plantvakStartY,
@@ -2105,8 +2105,8 @@ export default function PlantBedViewPage() {
                     }}
                   >
                     {/* Plantvak info - always within the plantvak area */}
-                    <div className="absolute top-2 left-2 bg-white/90 backdrop-blur-sm px-3 py-1 rounded-lg shadow-sm border">
-                      <div className="text-xs text-green-600">
+                    <div className="absolute top-2 left-2 bg-white/90 dark:bg-gray-800/90 backdrop-blur-sm px-3 py-1 rounded-lg shadow-sm border dark:border-gray-600">
+                      <div className="text-xs text-green-600 dark:text-green-400">
                         {plantBed.size} • {flowerPositions.length} bloemen
                       </div>
                     </div>
@@ -2196,7 +2196,7 @@ export default function PlantBedViewPage() {
                       
                       {/* Kleine naam label voor kleine bloemen */}
                       {flower.visual_width <= 60 && (
-                        <div className="absolute -bottom-6 left-1/2 transform -translate-x-1/2 text-xs font-medium text-gray-700 bg-white bg-opacity-90 px-2 py-1 rounded shadow-sm whitespace-nowrap">
+                        <div className="absolute -bottom-6 left-1/2 transform -translate-x-1/2 text-xs font-medium text-gray-700 dark:text-gray-300 bg-white dark:bg-gray-800 bg-opacity-90 dark:bg-opacity-90 px-2 py-1 rounded shadow-sm whitespace-nowrap">
                           {flower.name}
                         </div>
                       )}
@@ -2397,11 +2397,11 @@ export default function PlantBedViewPage() {
               )}
             </div>
           </div>
-              <div className="mt-4 text-sm text-gray-600 flex items-center justify-end">
+              <div className="mt-4 text-sm text-gray-600 dark:text-gray-400 flex items-center justify-end">
                 <div className="flex items-center gap-4">
                   <p className="text-xs">Zoom: {Math.round(scale * 100)}%</p>
                   {hasChanges && (
-                    <Badge variant="secondary" className="bg-orange-100 text-orange-800">
+                    <Badge variant="secondary" className="bg-orange-100 dark:bg-orange-900/30 text-orange-800 dark:text-orange-200">
                       Niet opgeslagen wijzigingen
                     </Badge>
                   )}
@@ -2412,10 +2412,10 @@ export default function PlantBedViewPage() {
             /* List View */
             <div className="space-y-4">
               {/* List Header */}
-              <div className="flex items-center justify-between p-4 bg-gray-50 rounded-lg">
+              <div className="flex items-center justify-between p-4 bg-gray-50 dark:bg-gray-800 rounded-lg">
                 <div className="flex items-center gap-2">
-                  <List className="h-5 w-5 text-gray-600" />
-                  <span className="font-medium text-gray-900">Bloemen Lijst</span>
+                  <List className="h-5 w-5 text-gray-600 dark:text-gray-400" />
+                  <span className="font-medium text-gray-900 dark:text-gray-100">Bloemen Lijst</span>
                   <Badge variant="secondary">{flowerPositions.length} bloemen</Badge>
                 </div>
               </div>
@@ -2423,10 +2423,10 @@ export default function PlantBedViewPage() {
               {/* Flowers List */}
               {flowerPositions.length === 0 ? (
                 <div className="text-center py-12">
-                  <Flower className="h-16 w-16 mx-auto text-gray-400 mb-4" />
-                  <h3 className="text-lg font-medium text-gray-900 mb-2">Nog geen bloemen</h3>
-                  <p className="text-gray-600 mb-4">Voeg bloemen toe aan dit plantvak.</p>
-                  <Button onClick={() => setIsAddingFlower(true)} className="bg-pink-600 hover:bg-pink-700">
+                  <Flower className="h-16 w-16 mx-auto text-gray-400 dark:text-gray-500 mb-4" />
+                  <h3 className="text-lg font-medium text-gray-900 dark:text-gray-100 mb-2">Nog geen bloemen</h3>
+                  <p className="text-gray-600 dark:text-gray-400 mb-4">Voeg bloemen toe aan dit plantvak.</p>
+                  <Button onClick={() => setIsAddingFlower(true)} className="bg-pink-600 hover:bg-pink-700 dark:bg-pink-600 dark:hover:bg-pink-700">
                     <Plus className="h-4 w-4 mr-2" />
                     Eerste Bloem Toevoegen
                   </Button>
@@ -2440,16 +2440,16 @@ export default function PlantBedViewPage() {
                           <div className="flex items-center gap-2">
                             <span className="text-2xl">{flower.emoji || '🌸'}</span>
                             <div>
-                              <h3 className="font-medium text-gray-900">{flower.name}</h3>
+                              <h3 className="font-medium text-gray-900 dark:text-gray-100">{flower.name}</h3>
                               {flower.category && (
-                                <p className="text-sm text-gray-500">{flower.category}</p>
+                                <p className="text-sm text-gray-500 dark:text-gray-400">{flower.category}</p>
                               )}
                             </div>
                           </div>
                           <div className={`w-3 h-3 rounded-full border-2 ${getStatusColor(flower.status || 'gezond')}`}></div>
                         </div>
                         
-                        <div className="space-y-2 text-sm text-gray-600 mb-4">
+                        <div className="space-y-2 text-sm text-gray-600 dark:text-gray-400 mb-4">
                           <div className="grid grid-cols-2 gap-2">
                             <div className="flex justify-between">
                               <span>Status:</span>
@@ -2460,7 +2460,7 @@ export default function PlantBedViewPage() {
                                 <span>Kleur:</span>
                                 <div className="flex items-center gap-1">
                                   <div
-                                    className="w-3 h-3 rounded-full border border-gray-300"
+                                    className="w-3 h-3 rounded-full border border-gray-300 dark:border-gray-600"
                                     style={{ backgroundColor: flower.color || flower.plant_color }}
                                   />
                                   <span className="text-xs">{flower.plant_color}</span>
@@ -2487,9 +2487,9 @@ export default function PlantBedViewPage() {
                             )}
                           </div>
                           {flower.notes && (
-                            <div className="mt-2 p-2 bg-gray-50 rounded">
-                              <span className="text-xs font-medium">Notities:</span>
-                              <p className="text-xs mt-1">{flower.notes}</p>
+                            <div className="mt-2 p-2 bg-gray-50 dark:bg-gray-800 rounded">
+                              <span className="text-xs font-medium text-gray-700 dark:text-gray-300">Notities:</span>
+                              <p className="text-xs mt-1 text-gray-600 dark:text-gray-400">{flower.notes}</p>
                             </div>
                           )}
                         </div>
@@ -2542,10 +2542,10 @@ export default function PlantBedViewPage() {
 
               {/* Tasks Section - Only in List View */}
               <div className="mt-8">
-                <div className="flex items-center justify-between p-4 bg-blue-50 rounded-lg mb-4">
+                <div className="flex items-center justify-between p-4 bg-blue-50 dark:bg-blue-950/30 rounded-lg mb-4">
                   <div className="flex items-center gap-3">
-                      <Calendar className="h-6 w-6 text-blue-700" />
-                      <span className="font-semibold text-gray-900 text-xl leading-snug">Taken voor dit Plantvak</span>
+                      <Calendar className="h-6 w-6 text-blue-700 dark:text-blue-300" />
+                      <span className="font-semibold text-gray-900 dark:text-gray-100 text-xl leading-snug">Taken voor dit Plantvak</span>
                       <Badge variant="secondary" className="text-sm">{tasks.length} taken</Badge>
                     </div>
                   <div className="flex gap-2">
@@ -2553,7 +2553,7 @@ export default function PlantBedViewPage() {
                       size="sm"
                       variant="outline"
                       onClick={() => handleAddTask()}
-                      className="text-blue-600 border-blue-200 hover:bg-blue-50"
+                      className="text-blue-600 dark:text-blue-400 border-blue-200 dark:border-blue-600 hover:bg-blue-50 dark:hover:bg-blue-950/30"
                     >
                       <Plus className="h-4 w-4 mr-1" />
                       Plantvak Taak
@@ -2563,7 +2563,7 @@ export default function PlantBedViewPage() {
                         size="sm"
                         variant="outline"
                         onClick={() => handleAddTask(flowerPositions[0].id)}
-                        className="text-green-600 border-green-200 hover:bg-green-50"
+                        className="text-green-600 dark:text-green-400 border-green-200 dark:border-green-600 hover:bg-green-50 dark:hover:bg-green-950/30"
                       >
                         <Plus className="h-4 w-4 mr-1" />
                         Bloem Taak
@@ -2575,14 +2575,14 @@ export default function PlantBedViewPage() {
                 {/* Tasks List */}
                 {loadingTasks ? (
                   <div className="text-center py-8">
-                    <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600 mx-auto"></div>
-                    <p className="text-gray-600 mt-2">Taken laden...</p>
+                    <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600 dark:border-blue-400 mx-auto"></div>
+                    <p className="text-gray-600 dark:text-gray-400 mt-2">Taken laden...</p>
                   </div>
                 ) : tasks.length === 0 ? (
                   <div className="text-center py-8">
-                    <Calendar className="h-12 w-12 mx-auto text-gray-400 mb-4" />
-                    <h3 className="text-lg font-medium text-gray-900 mb-2">Nog geen taken</h3>
-                    <p className="text-gray-600 mb-4">Voeg taken toe voor dit plantvak of specifieke bloemen.</p>
+                    <Calendar className="h-12 w-12 mx-auto text-gray-400 dark:text-gray-500 mb-4" />
+                    <h3 className="text-lg font-medium text-gray-900 dark:text-gray-100 mb-2">Nog geen taken</h3>
+                    <p className="text-gray-600 dark:text-gray-400 mb-4">Voeg taken toe voor dit plantvak of specifieke bloemen.</p>
                   </div>
                 ) : (
                   <div className="space-y-3">
@@ -2593,7 +2593,7 @@ export default function PlantBedViewPage() {
                       const isToday = task.due_date === new Date().toISOString().split('T')[0]
                       
                       return (
-                        <Card key={task.id} className={`transition-all duration-200 ${task.completed ? 'opacity-60' : ''} ${isOverdue ? 'border-red-200 bg-red-50' : isToday ? 'border-orange-200 bg-orange-50' : ''}`}>
+                        <Card key={task.id} className={`transition-all duration-200 ${task.completed ? 'opacity-60' : ''} ${isOverdue ? 'border-red-200 dark:border-red-700 bg-red-50 dark:bg-red-950/30' : isToday ? 'border-orange-200 dark:border-orange-700 bg-orange-50 dark:bg-orange-950/30' : ''}`}>
                           <CardContent className="p-4">
                             <div className="flex items-start gap-3">
                               {/* Checkbox */}
@@ -2603,13 +2603,13 @@ export default function PlantBedViewPage() {
                                   checked={task.completed}
                                   onChange={(e) => handleTaskComplete(task.id, e.target.checked)}
                                   disabled={updatingTasks.has(task.id)}
-                                  className={`w-4 h-4 text-blue-600 bg-gray-100 border-gray-300 rounded focus:ring-blue-500 transition-opacity ${
+                                  className={`w-4 h-4 text-blue-600 dark:text-blue-400 bg-gray-100 dark:bg-gray-800 border-gray-300 dark:border-gray-600 rounded focus:ring-blue-500 dark:focus:ring-blue-400 transition-opacity ${
                                     updatingTasks.has(task.id) ? 'opacity-50 cursor-not-allowed' : 'cursor-pointer'
                                   }`}
                                 />
                                 {updatingTasks.has(task.id) && (
                                   <div className="absolute mt-1 ml-1">
-                                    <div className="w-2 h-2 border border-blue-600 border-t-transparent rounded-full animate-spin"></div>
+                                    <div className="w-2 h-2 border border-blue-600 dark:border-blue-400 border-t-transparent rounded-full animate-spin"></div>
                                   </div>
                                 )}
                               </div>
@@ -2619,18 +2619,18 @@ export default function PlantBedViewPage() {
                                 <div className="flex items-start justify-between">
                                   <div className="flex-1 min-w-0">
                                       {/* Header: Plantvak → Bloem • Taak (one row) */}
-                                      <div className="flex items-center gap-2 mb-1 text-base text-gray-900 leading-snug">
-                                        <span className="text-gray-300" aria-hidden>•</span>
-                                        <span className={`font-semibold truncate ${task.completed ? 'line-through text-gray-500' : 'text-gray-900'}`}>{task.title}</span>
+                                      <div className="flex items-center gap-2 mb-1 text-base text-gray-900 dark:text-gray-100 leading-snug">
+                                        <span className="text-gray-300 dark:text-gray-500" aria-hidden>•</span>
+                                        <span className={`font-semibold truncate ${task.completed ? 'line-through text-gray-500 dark:text-gray-400' : 'text-gray-900 dark:text-gray-100'}`}>{task.title}</span>
                                       </div>
                                       {task.description && (
-                                        <p className={`text-sm mt-1 ${task.completed ? 'text-gray-500' : 'text-gray-700'}`}>
+                                        <p className={`text-sm mt-1 ${task.completed ? 'text-gray-500 dark:text-gray-400' : 'text-gray-700 dark:text-gray-300'}`}>
                                             {task.description}
                                           </p>
                                       )}
                                       
                                       {/* Task Meta Info */}
-                                      <div className="flex items-center gap-3 mt-2 text-xs text-gray-600">
+                                      <div className="flex items-center gap-3 mt-2 text-xs text-gray-600 dark:text-gray-400">
                                       <div className="flex items-center gap-1">
                                         {taskTypeConfig && (
                                           <>
@@ -2642,20 +2642,20 @@ export default function PlantBedViewPage() {
                                       
                                       <div className="flex items-center gap-1.5">
                                           <Clock className="h-3.5 w-3.5" />
-                                          <span className={isOverdue ? 'text-red-700 font-semibold' : isToday ? 'text-orange-700 font-semibold' : 'text-gray-700'}>
+                                          <span className={isOverdue ? 'text-red-700 dark:text-red-300 font-semibold' : isToday ? 'text-orange-700 dark:text-orange-300 font-semibold' : 'text-gray-700 dark:text-gray-300'}>
                                             {formatTaskDate(task.due_date)}
                                           </span>
                                         </div>
                                       
-                                      {task.plant_id ? (
+                                                                              {task.plant_id ? (
                                           <div className="flex items-center gap-2">
                                             <span className="text-lg">🌸</span>
-                                            <span className="font-semibold text-gray-900">{task.plant_name}</span>
+                                            <span className="font-semibold text-gray-900 dark:text-gray-100">{task.plant_name}</span>
                                           </div>
                                         ) : (
                                           <div className="flex items-center gap-2">
                                             <span className="text-lg">🌱</span>
-                                            <span className="font-semibold text-gray-900">Plantvak taak</span>
+                                            <span className="font-semibold text-gray-900 dark:text-gray-100">Plantvak taak</span>
                                           </div>
                                         )}
                                     </div>
@@ -2699,7 +2699,7 @@ export default function PlantBedViewPage() {
       {/* Resize Interface Overlay */}
       {showResizeInterface && selectedFlower && (
         <div 
-          className="fixed z-50 bg-white rounded-lg shadow-2xl border-2 border-blue-500 p-4"
+          className="fixed z-50 bg-white dark:bg-gray-800 rounded-lg shadow-2xl border-2 border-blue-500 dark:border-blue-400 p-4"
           style={{
             left: resizeInterfacePosition.x - 100,
             top: resizeInterfacePosition.y - 60,
@@ -2707,7 +2707,7 @@ export default function PlantBedViewPage() {
           }}
         >
           <div className="flex items-center gap-2 mb-2">
-            <div className="text-sm font-medium text-gray-700">
+            <div className="text-sm font-medium text-gray-700 dark:text-gray-300">
               🌸 {selectedFlower.name}
             </div>
             <Button
@@ -2731,7 +2731,7 @@ export default function PlantBedViewPage() {
               <Minus className="h-4 w-4" />
             </Button>
             
-            <div className="text-sm text-gray-600 min-w-[60px] text-center">
+            <div className="text-sm text-gray-600 dark:text-gray-400 min-w-[60px] text-center">
               {Math.min(selectedFlower.visual_width, selectedFlower.visual_height)}px
             </div>
             
@@ -2746,7 +2746,7 @@ export default function PlantBedViewPage() {
             </Button>
           </div>
           
-          <div className="text-xs text-gray-500 mt-1 text-center">
+          <div className="text-xs text-gray-500 dark:text-gray-400 mt-1 text-center">
             {selectedFlower.visual_width > 100 
               ? "🌸 Bloemenveld - meer bloemen bij groter maken"
               : "Dubbelklik = grootte aanpassen"

--- a/app/plants/[id]/page.tsx
+++ b/app/plants/[id]/page.tsx
@@ -220,9 +220,9 @@ export default function PlantDetailPage() {
         {/* Plant Details */}
         <div className="lg:col-span-2 space-y-6">
           {/* Basic Info */}
-          <Card className="border-2 border-green-200 bg-green-50/30">
+          <Card className="border-2 border-green-200 dark:border-green-700 bg-green-50/30 dark:bg-green-950/30">
             <CardHeader>
-              <CardTitle className="flex items-center gap-2 text-green-800">
+              <CardTitle className="flex items-center gap-2 text-green-800 dark:text-green-200">
                 <Leaf className="w-5 h-5" />
                 Basis Bloemgegevens
               </CardTitle>
@@ -230,8 +230,8 @@ export default function PlantDetailPage() {
             <CardContent className="space-y-4">
               <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                 <div>
-                  <label className="text-sm font-medium text-gray-700">Bloemnaam</label>
-                  <p className="text-lg font-semibold flex items-center gap-2">
+                  <label className="text-sm font-medium text-gray-700 dark:text-gray-300">Bloemnaam</label>
+                  <p className="text-lg font-semibold flex items-center gap-2 text-gray-900 dark:text-gray-100">
                     {plant.emoji && <span className="text-xl">{plant.emoji}</span>}
                     {plant.name}
                   </p>
@@ -239,23 +239,23 @@ export default function PlantDetailPage() {
                 
                 {plant.color && (
                   <div>
-                    <label className="text-sm font-medium text-gray-700">Kleur</label>
-                    <p className="text-lg font-medium text-gray-900">{plant.color}</p>
+                    <label className="text-sm font-medium text-gray-700 dark:text-gray-300">Kleur</label>
+                    <p className="text-lg font-medium text-gray-900 dark:text-gray-100">{plant.color}</p>
                   </div>
                 )}
 
                 {plant.height && (
                   <div>
-                    <label className="text-sm font-medium text-gray-700">Hoogte</label>
-                    <p className="text-lg font-medium text-gray-900">
+                    <label className="text-sm font-medium text-gray-700 dark:text-gray-300">Hoogte</label>
+                    <p className="text-lg font-medium text-gray-900 dark:text-gray-100">
                       {plant.height} cm
                     </p>
                   </div>
                 )}
 
                 <div>
-                  <label className="text-sm font-medium text-gray-700">Locatie</label>
-                  <p className="text-gray-900">{plant.plant_beds?.name} • {plant.plant_beds?.gardens?.name}</p>
+                  <label className="text-sm font-medium text-gray-700 dark:text-gray-300">Locatie</label>
+                  <p className="text-gray-900 dark:text-gray-100">{plant.plant_beds?.name} • {plant.plant_beds?.gardens?.name}</p>
                 </div>
               </div>
             </CardContent>
@@ -266,7 +266,7 @@ export default function PlantDetailPage() {
             <Card>
               <CardHeader>
                 <CardTitle className="flex items-center gap-2">
-                  <span className="w-5 h-5 text-blue-600">🔬</span>
+                  <span className="w-5 h-5 text-blue-600 dark:text-blue-400">🔬</span>
                   Wetenschappelijke Informatie
                 </CardTitle>
               </CardHeader>
@@ -274,15 +274,15 @@ export default function PlantDetailPage() {
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                   {plant.scientific_name && (
                     <div>
-                      <label className="text-sm font-medium text-gray-700">Wetenschappelijke naam</label>
-                      <p className="text-gray-900 italic">{plant.scientific_name}</p>
+                      <label className="text-sm font-medium text-gray-700 dark:text-gray-300">Wetenschappelijke naam</label>
+                      <p className="text-gray-900 dark:text-gray-100 italic">{plant.scientific_name}</p>
                     </div>
                   )}
 
                   {plant.variety && (
                     <div className={plant.scientific_name ? "md:col-span-1" : "md:col-span-2"}>
-                      <label className="text-sm font-medium text-gray-700">Variëteit</label>
-                      <p className="text-gray-900">{plant.variety}</p>
+                      <label className="text-sm font-medium text-gray-700 dark:text-gray-300">Variëteit</label>
+                      <p className="text-gray-900 dark:text-gray-100">{plant.variety}</p>
                     </div>
                   )}
                 </div>
@@ -295,7 +295,7 @@ export default function PlantDetailPage() {
             <Card>
               <CardHeader>
                 <CardTitle className="flex items-center gap-2">
-                  <Sun className="w-5 h-5 text-orange-600" />
+                  <Sun className="w-5 h-5 text-orange-600 dark:text-orange-400" />
                   Groei Informatie
                 </CardTitle>
               </CardHeader>
@@ -305,18 +305,18 @@ export default function PlantDetailPage() {
                     <div className="flex items-center gap-3">
                       {getSunIcon(plant.sun_preference)}
                       <div>
-                        <p className="text-sm text-gray-600">Zonvoorkeur</p>
-                        <p className="font-medium text-gray-900">{getSunLabel(plant.sun_preference)}</p>
+                        <p className="text-sm text-gray-600 dark:text-gray-400">Zonvoorkeur</p>
+                        <p className="font-medium text-gray-900 dark:text-gray-100">{getSunLabel(plant.sun_preference)}</p>
                       </div>
                     </div>
                   )}
 
                   {plant.plants_per_sqm && (
                     <div className="flex items-center gap-3">
-                      <Users className="w-5 h-5 text-green-500" />
+                      <Users className="w-5 h-5 text-green-500 dark:text-green-400" />
                       <div>
-                        <p className="text-sm text-gray-600">Planten per m²</p>
-                        <p className="font-medium text-gray-900">{plant.plants_per_sqm} stuks</p>
+                        <p className="text-sm text-gray-600 dark:text-gray-400">Planten per m²</p>
+                        <p className="font-medium text-gray-900 dark:text-gray-100">{plant.plants_per_sqm} stuks</p>
                       </div>
                     </div>
                   )}
@@ -324,22 +324,22 @@ export default function PlantDetailPage() {
                   {(plant.planting_date || plant.expected_harvest_date) && (
                     <div className="md:col-span-2">
                       <div className="flex items-center gap-3 mb-2">
-                        <Calendar className="w-5 h-5 text-blue-500" />
-                        <p className="text-sm font-medium text-gray-700">Planning</p>
+                        <Calendar className="w-5 h-5 text-blue-500 dark:text-blue-400" />
+                        <p className="text-sm font-medium text-gray-700 dark:text-gray-300">Planning</p>
                       </div>
                       <div className="grid grid-cols-1 md:grid-cols-2 gap-4 ml-8">
                         {plant.planting_date && (
                           <div>
-                            <p className="text-sm text-gray-600">Plantdatum</p>
-                            <p className="font-medium text-gray-900">
+                            <p className="text-sm text-gray-600 dark:text-gray-400">Plantdatum</p>
+                            <p className="font-medium text-gray-900 dark:text-gray-100">
                               {new Date(plant.planting_date).toLocaleDateString('nl-NL')}
                             </p>
                           </div>
                         )}
                         {plant.expected_harvest_date && (
                           <div>
-                            <p className="text-sm text-gray-600">Verwachte bloeitijd</p>
-                            <p className="font-medium text-gray-900">
+                            <p className="text-sm text-gray-600 dark:text-gray-400">Verwachte bloeitijd</p>
+                            <p className="font-medium text-gray-900 dark:text-gray-100">
                               {new Date(plant.expected_harvest_date).toLocaleDateString('nl-NL')}
                             </p>
                           </div>
@@ -357,37 +357,37 @@ export default function PlantDetailPage() {
             <Card>
               <CardHeader>
                 <CardTitle className="flex items-center gap-2">
-                  <span className="w-5 h-5 text-green-600">🌿</span>
+                  <span className="w-5 h-5 text-green-600 dark:text-green-400">🌿</span>
                   Verzorging
                 </CardTitle>
               </CardHeader>
               <CardContent className="space-y-4">
                 {plant.care_instructions && (
                   <div>
-                    <h4 className="font-medium mb-2 text-gray-700">Verzorgingsinstructies</h4>
-                    <p className="text-gray-900 bg-gray-50 p-3 rounded-md">{plant.care_instructions}</p>
+                    <h4 className="font-medium mb-2 text-gray-700 dark:text-gray-300">Verzorgingsinstructies</h4>
+                    <p className="text-gray-900 dark:text-gray-100 bg-gray-50 dark:bg-gray-800 p-3 rounded-md">{plant.care_instructions}</p>
                   </div>
                 )}
                 
                 {(plant.watering_frequency || plant.fertilizer_schedule) && (
                   <div>
-                    <h4 className="font-medium mb-3 text-gray-700">Verzorgingsschema</h4>
+                    <h4 className="font-medium mb-3 text-gray-700 dark:text-gray-300">Verzorgingsschema</h4>
                     <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                       {plant.watering_frequency && (
-                        <div className="flex items-center gap-3 bg-blue-50 p-3 rounded-md">
-                          <span className="text-blue-600">💧</span>
+                        <div className="flex items-center gap-3 bg-blue-50 dark:bg-blue-950/30 p-3 rounded-md">
+                          <span className="text-blue-600 dark:text-blue-400">💧</span>
                           <div>
-                            <p className="text-sm text-gray-600">Water frequentie</p>
-                            <p className="font-medium text-gray-900">Elke {plant.watering_frequency} dagen</p>
+                            <p className="text-sm text-gray-600 dark:text-gray-400">Water frequentie</p>
+                            <p className="font-medium text-gray-900 dark:text-gray-100">Elke {plant.watering_frequency} dagen</p>
                           </div>
                         </div>
                       )}
                       {plant.fertilizer_schedule && (
-                        <div className="flex items-center gap-3 bg-green-50 p-3 rounded-md">
-                          <span className="text-green-600">🧪</span>
+                        <div className="flex items-center gap-3 bg-green-50 dark:bg-green-950/30 p-3 rounded-md">
+                          <span className="text-green-600 dark:text-green-400">🧪</span>
                           <div>
-                            <p className="text-sm text-gray-600">Bemesting</p>
-                            <p className="font-medium text-gray-900">{plant.fertilizer_schedule}</p>
+                            <p className="text-sm text-gray-600 dark:text-gray-400">Bemesting</p>
+                            <p className="font-medium text-gray-900 dark:text-gray-100">{plant.fertilizer_schedule}</p>
                           </div>
                         </div>
                       )}
@@ -397,8 +397,8 @@ export default function PlantDetailPage() {
                 
                 {plant.notes && (
                   <div>
-                    <h4 className="font-medium mb-2 text-gray-700">Opmerkingen</h4>
-                    <p className="text-gray-900 bg-yellow-50 p-3 rounded-md border-l-4 border-yellow-400">{plant.notes}</p>
+                    <h4 className="font-medium mb-2 text-gray-700 dark:text-gray-300">Opmerkingen</h4>
+                    <p className="text-gray-900 dark:text-gray-100 bg-yellow-50 dark:bg-yellow-950/30 p-3 rounded-md border-l-4 border-yellow-400 dark:border-yellow-600">{plant.notes}</p>
                   </div>
                 )}
               </CardContent>
@@ -435,20 +435,20 @@ export default function PlantDetailPage() {
             <CardContent>
               <div className="space-y-3">
                 <div className="flex justify-between items-center">
-                  <span className="text-sm text-gray-600">Actieve taken</span>
+                  <span className="text-sm text-gray-600 dark:text-gray-400">Actieve taken</span>
                   <Badge variant="secondary">{activeTasks.length}</Badge>
                 </div>
                 <div className="flex justify-between items-center">
-                  <span className="text-sm text-gray-600">Vandaag</span>
-                  <Badge className="bg-orange-100 text-orange-800">{todayTasks.length}</Badge>
+                  <span className="text-sm text-gray-600 dark:text-gray-400">Vandaag</span>
+                  <Badge className="bg-orange-100 dark:bg-orange-900/30 text-orange-800 dark:text-orange-200">{todayTasks.length}</Badge>
                 </div>
                 <div className="flex justify-between items-center">
-                  <span className="text-sm text-gray-600">Verlopen</span>
+                  <span className="text-sm text-gray-600 dark:text-gray-400">Verlopen</span>
                   <Badge variant="destructive">{overdueTasks.length}</Badge>
                 </div>
                 <div className="flex justify-between items-center">
-                  <span className="text-sm text-gray-600">Afgerond</span>
-                  <Badge className="bg-green-100 text-green-800">{completedTasks.length}</Badge>
+                  <span className="text-sm text-gray-600 dark:text-gray-400">Afgerond</span>
+                  <Badge className="bg-green-100 dark:bg-green-900/30 text-green-800 dark:text-green-200">{completedTasks.length}</Badge>
                 </div>
               </div>
             </CardContent>
@@ -468,12 +468,12 @@ export default function PlantDetailPage() {
                   const isToday = task.due_date === new Date().toISOString().split('T')[0]
                   
                   return (
-                    <div key={task.id} className="border rounded-lg p-3 space-y-2">
+                    <div key={task.id} className="border border-border rounded-lg p-3 space-y-2">
                       <div className="flex items-start justify-between">
                         <div className="flex items-center gap-2">
                           <span className="text-sm">{taskTypeConfig?.icon || '📝'}</span>
                           <div className="flex-1">
-                            <p className="font-medium text-sm">{task.title}</p>
+                            <p className="font-medium text-sm text-foreground">{task.title}</p>
                             <div className="flex items-center gap-2 mt-1">
                               <Badge 
                                 variant={isOverdue ? "destructive" : isToday ? "default" : "secondary"}
@@ -518,9 +518,9 @@ export default function PlantDetailPage() {
           {tasks.length === 0 && (
             <Card>
               <CardContent className="p-6 text-center">
-                <Calendar className="w-12 h-12 text-gray-400 mx-auto mb-4" />
-                <h3 className="font-medium text-gray-900 mb-2">Nog geen taken</h3>
-                <p className="text-sm text-gray-600 mb-4">
+                <Calendar className="w-12 h-12 text-gray-400 dark:text-gray-500 mx-auto mb-4" />
+                <h3 className="font-medium text-gray-900 dark:text-gray-100 mb-2">Nog geen taken</h3>
+                <p className="text-sm text-gray-600 dark:text-gray-400 mb-4">
                   Voeg je eerste taak toe voor deze bloem.
                 </p>
                 <Button

--- a/components/bulk-operations-panel.tsx
+++ b/components/bulk-operations-panel.tsx
@@ -76,10 +76,10 @@ export function BulkOperationsPanel({
   }
 
   return (
-    <Card className="border-blue-200 bg-blue-50">
+    <Card className="border-blue-200 dark:border-blue-700 bg-blue-50 dark:bg-blue-950/30">
       <CardHeader>
         <div className="flex items-center justify-between">
-          <CardTitle className="flex items-center gap-2 text-blue-800">
+          <CardTitle className="flex items-center gap-2 text-blue-800 dark:text-blue-200">
             <Edit className="h-5 w-5" />
             Bulk Operaties
             <Badge variant="secondary" className="ml-2">
@@ -138,10 +138,10 @@ export function BulkOperationsPanel({
             {activeOperation === "move" && (
               <div className="space-y-4">
                 <div className="flex items-center gap-2">
-                  <Move className="h-5 w-5 text-blue-600" />
+                  <Move className="h-5 w-5 text-blue-600 dark:text-blue-400" />
                   <h3 className="font-medium">Planten verplaatsen</h3>
                 </div>
-                <p className="text-sm text-gray-600">
+                <p className="text-sm text-gray-600 dark:text-gray-400">
                   Verplaats {selectedCount} geselecteerde planten naar een ander plantvak.
                 </p>
                 <div className="space-y-2">
@@ -163,7 +163,7 @@ export function BulkOperationsPanel({
                   <Button
                     onClick={handleMove}
                     disabled={!targetBedId || loading}
-                    className="bg-blue-600 hover:bg-blue-700"
+                    className="bg-blue-600 hover:bg-blue-700 dark:bg-blue-600 dark:hover:bg-blue-700"
                   >
                     {loading ? (
                       <>
@@ -187,10 +187,10 @@ export function BulkOperationsPanel({
             {activeOperation === "update" && (
               <div className="space-y-4">
                 <div className="flex items-center gap-2">
-                  <Edit className="h-5 w-5 text-green-600" />
+                  <Edit className="h-5 w-5 text-green-600 dark:text-green-400" />
                   <h3 className="font-medium">Planten bijwerken</h3>
                 </div>
-                <p className="text-sm text-gray-600">
+                <p className="text-sm text-gray-600 dark:text-gray-400">
                   Werk eigenschappen bij van {selectedCount} geselecteerde planten.
                 </p>
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
@@ -242,7 +242,7 @@ export function BulkOperationsPanel({
                   />
                 </div>
                 <div className="flex gap-2">
-                  <Button onClick={handleUpdate} disabled={loading} className="bg-green-600 hover:bg-green-700">
+                  <Button onClick={handleUpdate} disabled={loading}                     className="bg-green-600 hover:bg-green-700 dark:bg-green-600 dark:hover:bg-green-700">
                     {loading ? (
                       <>
                         <RefreshCw className="h-4 w-4 mr-2 animate-spin" />
@@ -266,11 +266,11 @@ export function BulkOperationsPanel({
               <div className="space-y-4">
                 <div className="flex items-center gap-2">
                   <Trash2 className="h-5 w-5 text-red-600" />
-                  <h3 className="font-medium text-red-700">Planten verwijderen</h3>
+                  <h3 className="font-medium text-red-700 dark:text-red-300">Planten verwijderen</h3>
                 </div>
-                <div className="bg-red-50 border border-red-200 rounded-lg p-4">
-                  <p className="text-red-800 font-medium mb-2">⚠️ Waarschuwing</p>
-                  <p className="text-red-700 text-sm">
+                <div className="bg-red-50 dark:bg-red-950/30 border border-red-200 dark:border-red-700 rounded-lg p-4">
+                  <p className="text-red-800 dark:text-red-200 font-medium mb-2">⚠️ Waarschuwing</p>
+                  <p className="text-red-700 dark:text-red-300 text-sm">
                     Je staat op het punt om {selectedCount} planten permanent te verwijderen. Deze actie kan niet
                     ongedaan worden gemaakt.
                   </p>

--- a/components/plant-photo-gallery.tsx
+++ b/components/plant-photo-gallery.tsx
@@ -79,17 +79,17 @@ export function PlantPhotoGallery({ plantId, plantName, className }: PlantPhotoG
 
   if (loading) {
     return (
-      <Card className={`${className} border-2 border-green-200 bg-green-50/30`}>
+      <Card className={`${className} border-2 border-green-200 dark:border-green-700 bg-green-50/30 dark:bg-green-950/30`}>
         <CardHeader>
-          <CardTitle className="flex items-center gap-2 text-green-800">
-            <Camera className="w-5 h-5 text-blue-600" />
+          <CardTitle className="flex items-center gap-2 text-green-800 dark:text-green-200">
+            <Camera className="w-5 h-5 text-blue-600 dark:text-blue-400" />
             Foto's van {plantName}
           </CardTitle>
         </CardHeader>
         <CardContent>
           <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
             {[...Array(6)].map((_, i) => (
-              <div key={i} className="aspect-square bg-green-100 rounded-lg animate-pulse" />
+              <div key={i} className="aspect-square bg-green-100 dark:bg-green-900/30 rounded-lg animate-pulse" />
             ))}
           </div>
         </CardContent>
@@ -99,10 +99,10 @@ export function PlantPhotoGallery({ plantId, plantName, className }: PlantPhotoG
 
   if (error) {
     return (
-      <Card className={`${className} border-2 border-green-200 bg-green-50/30`}>
+      <Card className={`${className} border-2 border-green-200 dark:border-green-700 bg-green-50/30 dark:bg-green-950/30`}>
         <CardHeader>
-          <CardTitle className="flex items-center gap-2 text-green-800">
-            <Camera className="w-5 h-5 text-blue-600" />
+          <CardTitle className="flex items-center gap-2 text-green-800 dark:text-green-200">
+            <Camera className="w-5 h-5 text-blue-600 dark:text-blue-400" />
             Foto's van {plantName}
           </CardTitle>
         </CardHeader>
@@ -125,10 +125,10 @@ export function PlantPhotoGallery({ plantId, plantName, className }: PlantPhotoG
 
   if (!photoData || photoData.photos.length === 0) {
     return (
-      <Card className={`${className} border-2 border-green-200 bg-green-50/30`}>
+      <Card className={`${className} border-2 border-green-200 dark:border-green-700 bg-green-50/30 dark:bg-green-950/30`}>
         <CardHeader>
-          <CardTitle className="flex items-center gap-2 text-green-800">
-            <Camera className="w-5 h-5 text-blue-600" />
+          <CardTitle className="flex items-center gap-2 text-green-800 dark:text-green-200">
+            <Camera className="w-5 h-5 text-blue-600 dark:text-blue-400" />
             Foto's van {plantName}
           </CardTitle>
         </CardHeader>
@@ -155,11 +155,11 @@ export function PlantPhotoGallery({ plantId, plantName, className }: PlantPhotoG
 
   return (
     <>
-      <Card className={`${className} border-2 border-green-200 bg-green-50/30`}>
+      <Card className={`${className} border-2 border-green-200 dark:border-green-700 bg-green-50/30 dark:bg-green-950/30`}>
         <CardHeader>
           <div className="flex items-center justify-between">
-            <CardTitle className="flex items-center gap-2 text-green-800">
-              <Camera className="w-5 h-5 text-blue-600" />
+            <CardTitle className="flex items-center gap-2 text-green-800 dark:text-green-200">
+              <Camera className="w-5 h-5 text-blue-600 dark:text-blue-400" />
               Foto's van {plantName}
             </CardTitle>
             
@@ -168,21 +168,21 @@ export function PlantPhotoGallery({ plantId, plantName, className }: PlantPhotoG
               <Button
                 variant="outline"
                 size="sm"
-                className="border-green-300 hover:bg-green-100"
+                className="border-green-300 dark:border-green-600 hover:bg-green-100 dark:hover:bg-green-900/30"
                 onClick={() => navigateYear('prev')}
                 disabled={currentYear <= 2020}
               >
                 <ChevronLeft className="w-4 h-4" />
               </Button>
               
-              <Badge variant="outline" className="px-3 py-1 border-green-300 bg-green-100 text-green-800">
+              <Badge variant="outline" className="px-3 py-1 border-green-300 dark:border-green-600 bg-green-100 dark:bg-green-900/30 text-green-800 dark:text-green-200">
                 {currentYear}
               </Badge>
               
               <Button
                 variant="outline"
                 size="sm"
-                className="border-green-300 hover:bg-green-100"
+                className="border-green-300 dark:border-green-600 hover:bg-green-100 dark:hover:bg-green-900/30"
                 onClick={() => navigateYear('next')}
                 disabled={currentYear >= new Date().getFullYear()}
               >
@@ -191,10 +191,10 @@ export function PlantPhotoGallery({ plantId, plantName, className }: PlantPhotoG
             </div>
           </div>
           
-          <div className="flex items-center gap-2 text-sm text-green-700">
+          <div className="flex items-center gap-2 text-sm text-green-700 dark:text-green-300">
             <span>{photoData.totalCount} foto's dit jaar</span>
             {photoData.hasMorePhotos && (
-              <Badge variant="secondary" className="text-xs bg-green-200 text-green-800">
+              <Badge variant="secondary" className="text-xs bg-green-200 dark:bg-green-800 text-green-800 dark:text-green-200">
                 +{photoData.totalCount - 12} meer
               </Badge>
             )}
@@ -255,8 +255,8 @@ export function PlantPhotoGallery({ plantId, plantName, className }: PlantPhotoG
       <Dialog open={showPhotoDialog} onOpenChange={setShowPhotoDialog}>
         <DialogContent className="max-w-4xl max-h-[90vh] overflow-hidden">
           <DialogHeader>
-            <DialogTitle className="flex items-center gap-2 text-green-800">
-              <Camera className="w-5 h-5 text-blue-600" />
+            <DialogTitle className="flex items-center gap-2 text-green-800 dark:text-green-200">
+              <Camera className="w-5 h-5 text-blue-600 dark:text-blue-400" />
               Foto van {plantName}
             </DialogTitle>
           </DialogHeader>
@@ -275,7 +275,7 @@ export function PlantPhotoGallery({ plantId, plantName, className }: PlantPhotoG
                 <Button
                   variant="outline"
                   size="sm"
-                  className="absolute top-2 right-2 bg-white/90 hover:bg-white border-green-300"
+                  className="absolute top-2 right-2 bg-white/90 dark:bg-gray-800/90 hover:bg-white dark:hover:bg-gray-800 border-green-300 dark:border-green-600"
                   onClick={() => setShowPhotoDialog(false)}
                 >
                   <X className="w-4 h-4" />
@@ -286,36 +286,36 @@ export function PlantPhotoGallery({ plantId, plantName, className }: PlantPhotoG
               <div className="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm">
                 <div className="space-y-2">
                   <div className="flex items-center gap-2">
-                    <Calendar className="w-4 h-4 text-green-600" />
-                    <span className="font-medium text-green-800">Datum:</span>
-                    <span className="text-green-700">{formatPhotoDate(selectedPhoto.entry_date)}</span>
+                    <Calendar className="w-4 h-4 text-green-600 dark:text-green-400" />
+                    <span className="font-medium text-green-800 dark:text-green-200">Datum:</span>
+                    <span className="text-green-700 dark:text-green-300">{formatPhotoDate(selectedPhoto.entry_date)}</span>
                   </div>
                   
                   <div className="flex items-center gap-2">
-                    <MapPin className="w-4 h-4 text-blue-500" />
-                    <span className="font-medium text-green-800">Locatie:</span>
-                    <span className="text-green-700">{selectedPhoto.plant_bed_name}</span>
+                    <MapPin className="w-4 h-4 text-blue-500 dark:text-blue-400" />
+                    <span className="font-medium text-green-800 dark:text-green-200">Locatie:</span>
+                    <span className="text-green-700 dark:text-green-300">{selectedPhoto.plant_bed_name}</span>
                   </div>
                   
                   <div className="flex items-center gap-2">
-                    <Leaf className="w-4 h-4 text-green-500" />
-                    <span className="font-medium text-green-800">Plant:</span>
-                    <span className="text-green-700">{selectedPhoto.plant_name || plantName}</span>
+                    <Leaf className="w-4 h-4 text-green-500 dark:text-green-400" />
+                    <span className="font-medium text-green-800 dark:text-green-200">Plant:</span>
+                    <span className="text-green-700 dark:text-green-300">{selectedPhoto.plant_name || plantName}</span>
                   </div>
                 </div>
                 
                 <div className="space-y-2">
                   <div>
-                    <span className="font-medium text-green-800">Notities:</span>
-                    <p className="text-green-700 mt-1 bg-green-50 p-2 rounded">
+                    <span className="font-medium text-green-800 dark:text-green-200">Notities:</span>
+                    <p className="text-green-700 dark:text-green-300 mt-1 bg-green-50 dark:bg-green-950/30 p-2 rounded">
                       {selectedPhoto.notes || 'Geen notities toegevoegd'}
                     </p>
                   </div>
                   
                   {selectedPhoto.plant_variety && (
                     <div>
-                      <span className="font-medium text-green-800">Variëteit:</span>
-                      <p className="text-green-700 mt-1 bg-green-50 p-2 rounded">
+                      <span className="font-medium text-green-800 dark:text-green-200">Variëteit:</span>
+                      <p className="text-green-700 dark:text-green-300 mt-1 bg-green-50 dark:bg-green-950/30 p-2 rounded">
                         {selectedPhoto.plant_variety}
                       </p>
                     </div>

--- a/components/plants/plants-list.tsx
+++ b/components/plants/plants-list.tsx
@@ -146,7 +146,7 @@ export function PlantsList() {
           <CardContent className="pt-6">
             <div className="text-center py-8">
               <AlertCircle className="w-12 h-12 text-red-500 mx-auto mb-4" />
-              <h3 className="text-lg font-medium text-gray-900 dark:text-white mb-2">
+              <h3 className="text-lg font-medium text-gray-900 dark:text-gray-100 mb-2">
                 Fout bij laden
               </h3>
               <p className="text-gray-500 dark:text-gray-400 mb-4">
@@ -199,8 +199,8 @@ export function PlantsList() {
         <Card>
           <CardContent className="pt-6">
             <div className="text-center py-8">
-              <Leaf className="w-12 h-12 text-gray-400 mx-auto mb-4" />
-              <h3 className="text-lg font-medium text-gray-900 dark:text-white mb-2">
+              <Leaf className="w-12 h-12 text-gray-400 dark:text-gray-500 mx-auto mb-4" />
+              <h3 className="text-lg font-medium text-gray-900 dark:text-gray-100 mb-2">
                 Geen planten gevonden
               </h3>
               <p className="text-gray-500 dark:text-gray-400 mb-4">
@@ -225,19 +225,19 @@ export function PlantsList() {
               </CardHeader>
               <CardContent>
                 <div className="space-y-3">
-                  <div className="flex items-center text-sm text-gray-600 dark:text-gray-300">
+                  <div className="flex items-center text-sm text-gray-600 dark:text-gray-400">
                     <Calendar className="w-4 h-4 mr-2" />
                     Geplant: {new Date(plant.planted_date).toLocaleDateString('nl-NL')}
                   </div>
                   
                   {plant.last_watered && (
-                    <div className="flex items-center text-sm text-gray-600 dark:text-gray-300">
+                    <div className="flex items-center text-sm text-gray-600 dark:text-gray-400">
                       <Droplets className="w-4 h-4 mr-2" />
                       Laatst bewaterd: {new Date(plant.last_watered).toLocaleDateString('nl-NL')}
                     </div>
                   )}
                   
-                  <div className="flex items-center text-sm">
+                  <div className="flex items-center text-sm text-gray-600 dark:text-gray-400">
                     <span className="mr-2">Gezondheid:</span>
                     <span className={`font-medium ${getHealthColor(plant.health)}`}>
                       {getHealthLabel(plant.health)}

--- a/components/tasks/add-task-form.tsx
+++ b/components/tasks/add-task-form.tsx
@@ -377,7 +377,7 @@ export function AddTaskForm({ isOpen, onClose, onTaskAdded, preselectedPlantId, 
             <Button
               type="submit"
               disabled={loading || (!formData.plant_id && !formData.plant_bed_id) || !formData.title.trim()}
-              className="flex-1 bg-green-600 hover:bg-green-700"
+              className="flex-1"
             >
               {loading ? 'Toevoegen...' : 'Taak Toevoegen'}
             </Button>

--- a/components/ui/flower-selector.tsx
+++ b/components/ui/flower-selector.tsx
@@ -130,7 +130,7 @@ export function FlowerSelector({
             onClick={() => setIsOpen(!isOpen)}
           >
             <div className="flex items-center gap-2">
-              <Leaf className="h-4 w-4 text-green-600" />
+              <Leaf className="h-4 w-4 text-green-600 dark:text-green-400" />
               <div className="text-left">
                 <div className="font-medium">{selectedFlower.name}</div>
                 {selectedFlower.scientificName && (
@@ -145,11 +145,11 @@ export function FlowerSelector({
           
           {/* Flower details */}
           {showDetails && (
-            <Card className="mt-2 border-green-200">
+            <Card className="mt-2 border-green-200 dark:border-green-700">
               <CardContent className="p-3">
                 <div className="grid grid-cols-2 gap-2 text-sm">
                   <div className="flex items-center gap-1">
-                    <Calendar className="h-3 w-3 text-blue-500" />
+                    <Calendar className="h-3 w-3 text-blue-500 dark:text-blue-400" />
                     <span className="text-gray-600">Bloei:</span>
                     <span className="font-medium">{selectedFlower.bloeiperiode}</span>
                   </div>
@@ -174,7 +174,7 @@ export function FlowerSelector({
                       {FLOWER_CATEGORIES[selectedFlower.category]}
                     </Badge>
                     {selectedFlower.popular && (
-                      <Badge variant="outline" className="ml-1 text-xs bg-green-50 text-green-700">
+                      <Badge variant="outline" className="ml-1 text-xs bg-green-50 dark:bg-green-900/30 text-green-700 dark:text-green-300">
                         Populair
                       </Badge>
                     )}
@@ -246,8 +246,8 @@ export function FlowerSelector({
 
             {/* Popular flowers (when no search) */}
             {!searchQuery && showPopularFirst && (
-              <div className="p-3 border-b bg-green-50">
-                <h4 className="text-sm font-medium text-green-800 mb-2">Populaire bloemen</h4>
+              <div className="p-3 border-b bg-green-50 dark:bg-green-950/30">
+                <h4 className="text-sm font-medium text-green-800 dark:text-green-200 mb-2">Populaire bloemen</h4>
                 <div className="grid grid-cols-2 gap-1">
                   {popularFlowers.map((flower) => (
                     <Button
@@ -257,7 +257,7 @@ export function FlowerSelector({
                       className="justify-start h-8 text-xs"
                       onClick={() => handleFlowerSelect(flower)}
                     >
-                      <Leaf className="h-3 w-3 mr-1 text-green-600" />
+                                              <Leaf className="h-3 w-3 mr-1 text-green-600 dark:text-green-400" />
                       {flower.name}
                     </Button>
                   ))}
@@ -276,18 +276,18 @@ export function FlowerSelector({
                   <Button
                     key={flower.name}
                     variant="ghost"
-                    className="w-full justify-start p-3 h-auto hover:bg-green-50 border-b border-gray-100"
+                                            className="w-full justify-start p-3 h-auto hover:bg-green-50 dark:hover:bg-green-950/30 border-b border-gray-100 dark:border-gray-700"
                     onClick={() => handleFlowerSelect(flower)}
                   >
                     <div className="flex items-center gap-3 w-full">
-                      <Leaf className="h-4 w-4 text-green-600 flex-shrink-0" />
+                                              <Leaf className="h-4 w-4 text-green-600 dark:text-green-400 flex-shrink-0" />
                       <div className="text-left flex-1">
                         <div className="font-medium flex items-center gap-2">
                           {flower.name}
                           {flower.popular && (
-                            <Badge variant="secondary" className="px-1 py-0 text-xs bg-green-100 text-green-700">
-                              Populair
-                            </Badge>
+                                                      <Badge variant="secondary" className="px-1 py-0 text-xs bg-green-100 dark:bg-green-800 text-green-700 dark:text-green-300">
+                            Populair
+                          </Badge>
                           )}
                         </div>
                         {flower.scientificName && (

--- a/components/ui/plant-form.tsx
+++ b/components/ui/plant-form.tsx
@@ -143,18 +143,18 @@ export function PlantForm({
   return (
     <form onSubmit={onSubmit} onReset={onReset} className="space-y-6">
       {/* Required Fields Card */}
-      <Card className="border-2 border-green-200 bg-green-50/30">
+      <Card className="border-2 border-green-200 dark:border-green-700 bg-green-50/30 dark:bg-green-950/30">
         <CardHeader className="pb-4">
-          <CardTitle className="flex items-center gap-2 text-green-800">
+          <CardTitle className="flex items-center gap-2 text-green-800 dark:text-green-200">
             <Flower className="h-5 w-5" />
             Basis Bloemgegevens
-            <span className="text-sm font-normal text-green-600">(verplicht)</span>
+            <span className="text-sm font-normal text-green-600 dark:text-green-400">(verplicht)</span>
           </CardTitle>
         </CardHeader>
         <CardContent className="space-y-6">
           {/* Plant Name with suggestions */}
           <div className="space-y-2">
-            <Label htmlFor="name" className="text-sm font-medium text-gray-900 flex items-center gap-1">
+            <Label htmlFor="name" className="text-sm font-medium text-gray-900 dark:text-gray-100 flex items-center gap-1">
               Bloemnaam
               <span className="text-red-500">*</span>
             </Label>
@@ -166,7 +166,7 @@ export function PlantForm({
                 onChange={(e) => handleNameChange(e.target.value)}
                 onFocus={handleNameFocus}
                 onBlur={handleNameBlur}
-                className={`${errors.name ? "border-red-500 focus:border-red-500" : "border-gray-300 focus:border-green-500"} text-base`}
+                className={`${errors.name ? "border-red-500 focus:border-red-500" : "border-gray-300 dark:border-gray-600 focus:border-green-500 dark:focus:border-green-400"} text-base`}
                 required
                 autoComplete="off"
               />
@@ -183,7 +183,7 @@ export function PlantForm({
                     .map((flower) => (
                       <div
                         key={flower.name}
-                        className="px-4 py-3 cursor-pointer hover:bg-green-50 flex items-center gap-3 border-b border-gray-100 last:border-b-0"
+                        className="px-4 py-3 cursor-pointer hover:bg-green-50 dark:hover:bg-green-950/30 flex items-center gap-3 border-b border-gray-100 dark:border-gray-700 last:border-b-0"
                         onClick={() => selectFlower(flower)}
                       >
                         <span className="text-xl">{flower.emoji}</span>
@@ -196,7 +196,7 @@ export function PlantForm({
                   {data.name && !STANDARD_FLOWERS.some(f => 
                     f.name.toLowerCase().includes(data.name.toLowerCase())
                   ) && (
-                    <div className="px-4 py-3 text-gray-500 text-sm border-b border-gray-100">
+                    <div className="px-4 py-3 text-gray-500 dark:text-gray-400 text-sm border-b border-gray-100 dark:border-gray-700">
                       <div className="flex items-center gap-2">
                         <span className="text-lg">{DEFAULT_FLOWER_EMOJI}</span>
                         <span>"{data.name}" als nieuwe bloem</span>
@@ -207,7 +207,7 @@ export function PlantForm({
               )}
             </div>
             {errors.name && (
-              <div className="flex items-center gap-2 text-red-600 text-sm bg-red-50 p-2 rounded-md">
+              <div className="flex items-center gap-2 text-red-600 dark:text-red-400 text-sm bg-red-50 dark:bg-red-950/30 p-2 rounded-md">
                 <AlertCircle className="h-4 w-4 flex-shrink-0" />
                 {errors.name}
               </div>
@@ -216,7 +216,7 @@ export function PlantForm({
 
           {/* Color */}
           <div className="space-y-2">
-            <Label htmlFor="color" className="text-sm font-medium text-gray-900 flex items-center gap-1">
+            <Label htmlFor="color" className="text-sm font-medium text-gray-900 dark:text-gray-100 flex items-center gap-1">
               Kleur
               <span className="text-red-500">*</span>
             </Label>
@@ -225,12 +225,12 @@ export function PlantForm({
               placeholder="Bijv. Rood, Geel, Wit, Roze"
               value={data.color}
               onChange={(e) => handleFieldChange('color', e.target.value)}
-              className={`${errors.color ? "border-red-500 focus:border-red-500" : "border-gray-300 focus:border-green-500"} text-base`}
+                              className={`${errors.color ? "border-red-500 focus:border-red-500" : "border-gray-300 dark:border-gray-600 focus:border-green-500 dark:focus:border-green-400"} text-base`}
               required
               autoComplete="off"
             />
             {errors.color && (
-              <div className="flex items-center gap-2 text-red-600 text-sm bg-red-50 p-2 rounded-md">
+              <div className="flex items-center gap-2 text-red-600 dark:text-red-400 text-sm bg-red-50 dark:bg-red-950/30 p-2 rounded-md">
                 <AlertCircle className="h-4 w-4 flex-shrink-0" />
                 {errors.color}
               </div>
@@ -239,24 +239,24 @@ export function PlantForm({
 
           {/* Height */}
           <div className="space-y-2">
-            <Label htmlFor="height" className="text-sm font-medium text-gray-900 flex items-center gap-1">
-              Hoogte (cm)
-              <span className="text-red-500">*</span>
-            </Label>
+                                  <Label htmlFor="height" className="text-sm font-medium text-gray-900 dark:text-gray-100 flex items-center gap-1">
+                        Hoogte (cm)
+                        <span className="text-red-500">*</span>
+                      </Label>
             <Input
               id="height"
               type="number"
               placeholder="Bijv. 30, 60, 150"
               value={data.height}
               onChange={(e) => handleFieldChange('height', e.target.value)}
-              className={`${errors.height ? "border-red-500 focus:border-red-500" : "border-gray-300 focus:border-green-500"} text-base`}
+                              className={`${errors.height ? "border-red-500 focus:border-red-500" : "border-gray-300 dark:border-gray-600 focus:border-green-500 dark:focus:border-green-400"} text-base`}
               required
               min="1"
               max="500"
               autoComplete="off"
             />
             {errors.height && (
-              <div className="flex items-center gap-2 text-red-600 text-sm bg-red-50 p-2 rounded-md">
+              <div className="flex items-center gap-2 text-red-600 dark:text-red-400 text-sm bg-red-50 dark:bg-red-950/30 p-2 rounded-md">
                 <AlertCircle className="h-4 w-4 flex-shrink-0" />
                 {errors.height}
               </div>
@@ -269,29 +269,29 @@ export function PlantForm({
       {showAdvanced && (
         <Collapsible open={isAdvancedOpen} onOpenChange={setIsAdvancedOpen}>
           <CollapsibleTrigger asChild>
-            <Card className="cursor-pointer hover:shadow-md transition-shadow border-gray-200 bg-gray-50/30">
+            <Card className="cursor-pointer hover:shadow-md transition-shadow border-gray-200 dark:border-gray-700 bg-gray-50/30 dark:bg-gray-800/30">
               <CardHeader className="pb-4">
                 <div className="flex items-center justify-between">
                   <div className="flex items-center gap-2">
                     <Settings className="h-5 w-5 text-gray-600" />
-                    <CardTitle className="text-gray-800">
+                    <CardTitle className="text-gray-800 dark:text-gray-200">
                       Aanvullende Informatie
-                      <span className="text-sm font-normal text-gray-600 ml-2">(optioneel)</span>
+                      <span className="text-sm font-normal text-gray-600 dark:text-gray-400 ml-2">(optioneel)</span>
                     </CardTitle>
                     {filledOptionalFields > 0 && (
-                      <span className="bg-blue-100 text-blue-800 text-xs px-2 py-1 rounded-full">
+                      <span className="bg-blue-100 dark:bg-blue-900/30 text-blue-800 dark:text-blue-200 text-xs px-2 py-1 rounded-full">
                         {filledOptionalFields} ingevuld
                       </span>
                     )}
                   </div>
                   <div className="flex items-center gap-2">
-                    <span className="text-sm text-gray-500">
+                    <span className="text-sm text-gray-500 dark:text-gray-400">
                       {isAdvancedOpen ? 'Inklappen' : 'Uitklappen'}
                     </span>
                     {isAdvancedOpen ? (
-                      <ChevronUp className="h-5 w-5 text-gray-600" />
+                      <ChevronUp className="h-5 w-5 text-gray-600 dark:text-gray-400" />
                     ) : (
-                      <ChevronDown className="h-5 w-5 text-gray-600" />
+                      <ChevronDown className="h-5 w-5 text-gray-600 dark:text-gray-400" />
                     )}
                   </div>
                 </div>
@@ -300,71 +300,71 @@ export function PlantForm({
           </CollapsibleTrigger>
           
           <CollapsibleContent className="mt-4">
-            <Card className="border-gray-200">
+            <Card className="border-gray-200 dark:border-gray-700">
               <CardContent className="pt-6 space-y-6">
                 {/* Scientific Information Section */}
                 <div className="space-y-4">
-                  <div className="flex items-center gap-2 pb-2 border-b border-gray-200">
-                    <Info className="h-4 w-4 text-gray-600" />
-                    <h4 className="font-medium text-gray-900">Wetenschappelijke Informatie</h4>
+                  <div className="flex items-center gap-2 pb-2 border-b border-gray-200 dark:border-gray-700">
+                    <Info className="h-4 w-4 text-gray-600 dark:text-gray-400" />
+                    <h4 className="font-medium text-gray-900 dark:text-gray-100">Wetenschappelijke Informatie</h4>
                   </div>
                   <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                     <div className="space-y-2">
-                      <Label htmlFor="scientificName" className="text-sm font-medium text-gray-700">
+                      <Label htmlFor="scientificName" className="text-sm font-medium text-gray-700 dark:text-gray-300">
                         Wetenschappelijke naam
                       </Label>
-                      <Input
-                        id="scientificName"
-                        placeholder="Bijv. Rosa rubiginosa"
-                        value={data.scientificName}
-                        onChange={(e) => handleFieldChange('scientificName', e.target.value)}
-                        className="border-gray-300 focus:border-blue-500"
-                        autoComplete="off"
-                      />
+                                              <Input
+                          id="scientificName"
+                          placeholder="Bijv. Rosa rubiginosa"
+                          value={data.scientificName}
+                          onChange={(e) => handleFieldChange('scientificName', e.target.value)}
+                          className="border-gray-300 dark:border-gray-600 focus:border-blue-500 dark:focus:border-blue-400"
+                          autoComplete="off"
+                        />
                     </div>
 
                     <div className="space-y-2 md:col-span-2">
-                      <Label htmlFor="variety" className="text-sm font-medium text-gray-700">
+                      <Label htmlFor="variety" className="text-sm font-medium text-gray-700 dark:text-gray-300">
                         Variëteit
                       </Label>
-                      <Input
-                        id="variety"
-                        placeholder="Bijv. Red Eden, Double Delight"
-                        value={data.variety}
-                        onChange={(e) => handleFieldChange('variety', e.target.value)}
-                        className="border-gray-300 focus:border-blue-500"
-                        autoComplete="off"
-                      />
+                                              <Input
+                          id="variety"
+                          placeholder="Bijv. Red Eden, Double Delight"
+                          value={data.variety}
+                          onChange={(e) => handleFieldChange('variety', e.target.value)}
+                          className="border-gray-300 dark:border-gray-600 focus:border-blue-500 dark:focus:border-blue-400"
+                          autoComplete="off"
+                        />
                     </div>
                   </div>
                 </div>
 
                 {/* Growing Information Section */}
                 <div className="space-y-4">
-                  <div className="flex items-center gap-2 pb-2 border-b border-gray-200">
-                    <Flower className="h-4 w-4 text-gray-600" />
-                    <h4 className="font-medium text-gray-900">Groei Informatie</h4>
+                  <div className="flex items-center gap-2 pb-2 border-b border-gray-200 dark:border-gray-700">
+                    <Flower className="h-4 w-4 text-gray-600 dark:text-gray-400" />
+                    <h4 className="font-medium text-gray-900 dark:text-gray-100">Groei Informatie</h4>
                   </div>
                   <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                     <div className="space-y-2">
-                      <Label htmlFor="plantsPerSqm" className="text-sm font-medium text-gray-700">
+                      <Label htmlFor="plantsPerSqm" className="text-sm font-medium text-gray-700 dark:text-gray-300">
                         Planten per m²
                       </Label>
-                      <Input
-                        id="plantsPerSqm"
-                        type="number"
-                        placeholder="Bijv. 4"
-                        value={data.plantsPerSqm}
-                        onChange={(e) => handleFieldChange('plantsPerSqm', e.target.value)}
-                        className="border-gray-300 focus:border-blue-500"
-                        min="1"
-                        max="100"
-                        autoComplete="off"
-                      />
+                                              <Input
+                          id="plantsPerSqm"
+                          type="number"
+                          placeholder="Bijv. 4"
+                          value={data.plantsPerSqm}
+                          onChange={(e) => handleFieldChange('plantsPerSqm', e.target.value)}
+                          className="border-gray-300 dark:border-gray-600 focus:border-blue-500 dark:focus:border-blue-400"
+                          min="1"
+                          max="100"
+                          autoComplete="off"
+                        />
                     </div>
 
                     <div className="space-y-2">
-                      <Label htmlFor="sunPreference" className="text-sm font-medium text-gray-700">
+                      <Label htmlFor="sunPreference" className="text-sm font-medium text-gray-700 dark:text-gray-300">
                         Zonvoorkeur
                       </Label>
                       <Select 
@@ -373,7 +373,7 @@ export function PlantForm({
                           handleFieldChange('sunPreference', value)
                         }
                       >
-                        <SelectTrigger className="border-gray-300 focus:border-blue-500">
+                        <SelectTrigger className="border-gray-300 dark:border-gray-600 focus:border-blue-500 dark:focus:border-blue-400">
                           <SelectValue />
                         </SelectTrigger>
                         <SelectContent>
@@ -388,48 +388,48 @@ export function PlantForm({
 
                 {/* Planning Section */}
                 <div className="space-y-4">
-                  <div className="flex items-center gap-2 pb-2 border-b border-gray-200">
-                    <span className="h-4 w-4 text-gray-600">📅</span>
-                    <h4 className="font-medium text-gray-900">Planning & Status</h4>
+                  <div className="flex items-center gap-2 pb-2 border-b border-gray-200 dark:border-gray-700">
+                    <span className="h-4 w-4 text-gray-600 dark:text-gray-400">📅</span>
+                    <h4 className="font-medium text-gray-900 dark:text-gray-100">Planning & Status</h4>
                   </div>
                   <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                     <div className="space-y-2">
-                      <Label htmlFor="plantingDate" className="text-sm font-medium text-gray-700">
-                        Plantdatum
-                      </Label>
+                                              <Label htmlFor="plantingDate" className="text-sm font-medium text-gray-700 dark:text-gray-300">
+                          Plantdatum
+                        </Label>
                       <Input
                         id="plantingDate"
                         type="date"
                         value={data.plantingDate}
                         onChange={(e) => handleFieldChange('plantingDate', e.target.value)}
-                        className="border-gray-300 focus:border-blue-500"
+                        className="border-gray-300 dark:border-gray-600 focus:border-blue-500 dark:focus:border-blue-400"
                       />
                     </div>
 
                     <div className="space-y-2">
-                      <Label htmlFor="expectedHarvestDate" className="text-sm font-medium text-gray-700">
-                        Verwachte bloeitijd
-                      </Label>
+                                              <Label htmlFor="expectedHarvestDate" className="text-sm font-medium text-gray-700 dark:text-gray-300">
+                          Verwachte bloeitijd
+                        </Label>
                       <Input
                         id="expectedHarvestDate"
                         type="date"
                         value={data.expectedHarvestDate}
                         onChange={(e) => handleFieldChange('expectedHarvestDate', e.target.value)}
-                        className="border-gray-300 focus:border-blue-500"
+                        className="border-gray-300 dark:border-gray-600 focus:border-blue-500 dark:focus:border-blue-400"
                       />
                     </div>
 
                     <div className="space-y-2 md:col-span-2">
-                      <Label htmlFor="status" className="text-sm font-medium text-gray-700">
-                        Status
-                      </Label>
+                                              <Label htmlFor="status" className="text-sm font-medium text-gray-700 dark:text-gray-300">
+                          Status
+                        </Label>
                       <Select 
                         value={data.status} 
                         onValueChange={(value: "gezond" | "aandacht_nodig" | "ziek" | "dood" | "geoogst") => 
                           handleFieldChange('status', value)
                         }
                       >
-                        <SelectTrigger className="border-gray-300 focus:border-blue-500">
+                        <SelectTrigger className="border-gray-300 dark:border-gray-600 focus:border-blue-500 dark:focus:border-blue-400">
                           <SelectValue />
                         </SelectTrigger>
                         <SelectContent>
@@ -446,42 +446,42 @@ export function PlantForm({
 
                 {/* Care Instructions Section */}
                 <div className="space-y-4">
-                  <div className="flex items-center gap-2 pb-2 border-b border-gray-200">
-                    <span className="h-4 w-4 text-gray-600">🌿</span>
-                    <h4 className="font-medium text-gray-900">Verzorging</h4>
+                  <div className="flex items-center gap-2 pb-2 border-b border-gray-200 dark:border-gray-700">
+                    <span className="h-4 w-4 text-gray-600 dark:text-gray-400">🌿</span>
+                    <h4 className="font-medium text-gray-900 dark:text-gray-100">Verzorging</h4>
                   </div>
                   <div className="space-y-4">
                     <div className="space-y-2">
-                      <Label htmlFor="notes" className="text-sm font-medium text-gray-700">
-                        Opmerkingen
-                      </Label>
+                                              <Label htmlFor="notes" className="text-sm font-medium text-gray-700 dark:text-gray-300">
+                          Opmerkingen
+                        </Label>
                       <Textarea
                         id="notes"
                         placeholder="Bijv. Mooi in combinatie met lavendel, bloeit van mei tot oktober..."
                         value={data.notes}
                         onChange={(e) => handleFieldChange('notes', e.target.value)}
-                        className="border-gray-300 focus:border-blue-500 min-h-[80px]"
+                        className="border-gray-300 dark:border-gray-600 focus:border-blue-500 dark:focus:border-blue-400 min-h-[80px]"
                         rows={3}
                       />
                     </div>
 
                     <div className="space-y-2">
-                      <Label htmlFor="careInstructions" className="text-sm font-medium text-gray-700">
-                        Verzorgingsinstructies
-                      </Label>
+                                              <Label htmlFor="careInstructions" className="text-sm font-medium text-gray-700 dark:text-gray-300">
+                          Verzorgingsinstructies
+                        </Label>
                       <Textarea
                         id="careInstructions"
                         placeholder="Bijv. Wekelijks water geven, maandelijks bemesten, dode bloemen wegknippen..."
                         value={data.careInstructions}
                         onChange={(e) => handleFieldChange('careInstructions', e.target.value)}
-                        className="border-gray-300 focus:border-blue-500 min-h-[80px]"
+                        className="border-gray-300 dark:border-gray-600 focus:border-blue-500 dark:focus:border-blue-400 min-h-[80px]"
                         rows={3}
                       />
                     </div>
 
                     <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                       <div className="space-y-2">
-                        <Label htmlFor="wateringFrequency" className="text-sm font-medium text-gray-700">
+                        <Label htmlFor="wateringFrequency" className="text-sm font-medium text-gray-700 dark:text-gray-300">
                           Water frequentie (dagen)
                         </Label>
                         <Input
@@ -490,7 +490,7 @@ export function PlantForm({
                           placeholder="Bijv. 3"
                           value={data.wateringFrequency}
                           onChange={(e) => handleFieldChange('wateringFrequency', e.target.value)}
-                          className="border-gray-300 focus:border-blue-500"
+                          className="border-gray-300 dark:border-gray-600 focus:border-blue-500 dark:focus:border-blue-400"
                           min="1"
                           max="365"
                           autoComplete="off"
@@ -498,7 +498,7 @@ export function PlantForm({
                       </div>
 
                       <div className="space-y-2">
-                        <Label htmlFor="fertilizerSchedule" className="text-sm font-medium text-gray-700">
+                        <Label htmlFor="fertilizerSchedule" className="text-sm font-medium text-gray-700 dark:text-gray-300">
                           Bemestingsschema
                         </Label>
                         <Input
@@ -506,7 +506,7 @@ export function PlantForm({
                           placeholder="Bijv. Wekelijks, Maandelijks"
                           value={data.fertilizerSchedule}
                           onChange={(e) => handleFieldChange('fertilizerSchedule', e.target.value)}
-                          className="border-gray-300 focus:border-blue-500"
+                          className="border-gray-300 dark:border-gray-600 focus:border-blue-500 dark:focus:border-blue-400"
                           autoComplete="off"
                         />
                       </div>
@@ -520,11 +520,11 @@ export function PlantForm({
       )}
 
       {/* Submit buttons */}
-      <div className="flex gap-3 pt-6 border-t border-gray-200">
+      <div className="flex gap-3 pt-6 border-t border-gray-200 dark:border-gray-700">
         <Button 
           type="submit" 
           disabled={isSubmitting || !data.name.trim() || !data.color.trim() || !data.height.trim()}
-          className="flex-1 bg-green-600 hover:bg-green-700 text-white"
+                          className="flex-1"
           size="lg"
         >
           {isSubmitting ? (


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Remove hardcoded colors to fix white screens in dark mode on plant and detail pages.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The dark mode implementation had several hardcoded background, text, and border colors that did not adapt to the dark theme. This resulted in white elements and poor readability on various screens, particularly the plant and garden detail pages and related components. This PR introduces dark mode specific Tailwind classes to ensure all UI elements correctly respond to the selected theme.

---
<a href="https://cursor.com/background-agent?bcId=bc-2b8b457e-ff2a-40ae-9a2f-b97765fcb1ea">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2b8b457e-ff2a-40ae-9a2f-b97765fcb1ea">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

