### PR TITLE
Fix and improve plant bed automatic lettering

### DIFF
--- a/PLANTVAK_FUNCTIONALITEIT.md
+++ b/PLANTVAK_FUNCTIONALITEIT.md
@@ -1,0 +1,84 @@
+# Plantvak Functionaliteit - Implementatie Overzicht
+
+## ✅ Wat is gebouwd
+
+### 1. **Automatische Letter Toewijzing**
+- Plantvakken krijgen automatisch een letter toegewezen (A, B, C, etc.)
+- De letter wordt zowel de naam als de identificatie (`letter_code`)
+- Na Z gaat het verder met AA, AB, AC, etc. (zoals Excel kolommen)
+- Geen handmatige invoer van namen meer nodig
+- Implementatie in `/lib/services/plantvak.service.ts`
+
+### 2. **Vereenvoudigd Formulier** (`/app/gardens/[id]/plant-beds/new/page.tsx`)
+- **Verplichte velden:**
+  - ✅ Grootte
+  - ✅ Bodemtype (dropdown)
+  - ✅ Zonligging (dropdown)
+- **Optionele velden:**
+  - ✅ Locatie
+  - ✅ Beschrijving
+- **Visuele verbeteringen:**
+  - Prominente weergave van de volgende letter code
+  - Grote groene cirkel met de letter
+  - Overzicht van bestaande plantvakken
+  - Informatiekaart over het letter systeem
+
+### 3. **Lijst Pagina Verbeteringen** (`/app/gardens/[id]/plant-beds/page.tsx`)
+- Letter codes worden prominent weergegeven
+- Verwijder knop toegevoegd aan elk plantvak
+- Bevestigingsdialoog voor verwijderen
+- Waarschuwing als plantvak bloemen bevat
+
+### 4. **Opgeloste Problemen**
+- ✅ Toevoegen button werkt nu correct
+- ✅ Location is nu optioneel (niet meer verplicht)
+- ✅ Verwijderen van plantvakken werkt via lijst pagina
+- ✅ Formulier validatie werkt correct
+
+## 📋 Technische Details
+
+### Database Model
+```typescript
+interface Plantvak {
+  id: string
+  garden_id: string
+  name: string              // Automatisch: "A", "B", "C", etc.
+  letter_code?: string      // Zelfde als name
+  location?: string         // Optioneel
+  size?: string            // Verplicht
+  soil_type?: string       // Verplicht
+  sun_exposure?: string    // Verplicht
+  description?: string     // Optioneel
+  // ... andere velden
+}
+```
+
+### Letter Code Generatie Logica
+1. Probeert eerst enkele letters (A-Z)
+2. Daarna dubbele letters (AA-ZZ)
+3. Voor elk nieuw plantvak wordt de eerstvolgende beschikbare letter gebruikt
+4. Letters worden gesorteerd weergegeven
+
+## 🎯 User Experience Verbeteringen
+
+1. **Geen namen verzinnen**: Gebruikers hoeven geen creatieve namen meer te bedenken
+2. **Consistentie**: Alle plantvakken hebben een uniforme naamgeving
+3. **Makkelijk refereren**: "Plantvak B" is makkelijker te onthouden dan lange namen
+4. **Geen duplicaten**: Systeem voorkomt automatisch dubbele namen
+5. **Visuele duidelijkheid**: Letter codes worden overal prominent weergegeven
+
+## 🚀 Gebruik
+
+1. Ga naar een tuin
+2. Klik op "Nieuw Plantvak"
+3. Vul alleen de verplichte velden in (Grootte, Bodemtype, Zonligging)
+4. Het systeem toont automatisch welke letter het plantvak krijgt
+5. Klik op "Plantvak Aanmaken"
+6. Het plantvak wordt aangemaakt met de automatische letter als naam
+
+## 🔧 Toekomstige Verbeteringen (indien gewenst)
+
+- [ ] Mogelijkheid om letters te hergebruiken na verwijdering
+- [ ] Optie om handmatig een alias toe te voegen naast de letter
+- [ ] Export functie met letter codes
+- [ ] Bulk operaties op basis van letter ranges (bijv. A-D water geven)


### PR DESCRIPTION
Automate plant bed naming with sequential letter codes, simplify the creation form, and enable deletion directly from the list view.

This PR addresses several critical issues: the 'add' button for new plant beds was previously non-functional, the 'location' field was incorrectly marked as mandatory, and there was no direct way to delete plant beds from the main list, significantly hindering user workflow.

---
<a href="https://cursor.com/background-agent?bcId=bc-1c8baeff-9b87-4892-b5e2-af5e96a8ce55">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1c8baeff-9b87-4892-b5e2-af5e96a8ce55">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

