### PR TITLE
Fix garden overview filter for flower months

### DIFF
--- a/app/gardens/[id]/plantvak-view/[bedId]/page.tsx
+++ b/app/gardens/[id]/plantvak-view/[bedId]/page.tsx
@@ -48,6 +48,7 @@ import { TaskService } from "@/lib/services/task.service"
 import { AddTaskForm } from "@/components/tasks/add-task-form"
 import { PlantForm, PlantFormData, PlantFormErrors, createInitialPlantFormData } from "@/components/ui/plant-form"
 import type { Garden, PlantBedWithPlants, PlantWithPosition } from "@/lib/supabase"
+import { DUTCH_FLOWERS } from "@/lib/dutch-flowers"
 import type { TaskWithPlantInfo, WeeklyTask } from "@/lib/types/tasks"
 import { getTaskTypeConfig, getPriorityConfig, formatTaskDate } from "@/lib/types/tasks"
 import { uploadImage, type UploadResult } from "@/lib/storage"
@@ -767,6 +768,12 @@ export default function PlantBedViewPage() {
         }
       }
       
+      // Find bloom period from Dutch flowers database
+      const dutchFlowerData = DUTCH_FLOWERS.find(f => 
+        f.name.toLowerCase() === newFlower.name.toLowerCase() ||
+        f.scientificName?.toLowerCase() === newFlower.name.toLowerCase()
+      );
+      
       const newPlant = await createVisualPlant({
         plant_bed_id: plantBed.id,
         name: newFlower.name,
@@ -782,7 +789,8 @@ export default function PlantBedViewPage() {
         category: newFlower.isStandardFlower ? 'Standaard' : 'Aangepast',
         notes: newFlower.notes || '',
         planting_date: newFlower.plantingDate || '',
-        bloom_period: newFlower.expectedHarvestDate || ''
+        bloom_period: dutchFlowerData?.bloeiperiode || newFlower.bloom_period || '',
+        expected_harvest_date: newFlower.expectedHarvestDate || ''
       })
 
       if (newPlant) {
@@ -817,13 +825,20 @@ export default function PlantBedViewPage() {
     }
 
     try {
+      // Find bloom period from Dutch flowers database
+      const dutchFlowerData = DUTCH_FLOWERS.find(f => 
+        f.name.toLowerCase() === newFlower.name.toLowerCase() ||
+        f.scientificName?.toLowerCase() === newFlower.name.toLowerCase()
+      );
+      
       const updatedPlant = await updatePlantPosition(selectedFlower.id, {
         name: newFlower.name,
         color: newFlower.color,
         status: newFlower.status,
         emoji: newFlower.emoji,
         planting_date: newFlower.plantingDate || '',
-        bloom_period: newFlower.expectedHarvestDate || ''
+        bloom_period: dutchFlowerData?.bloeiperiode || newFlower.bloom_period || selectedFlower.bloom_period || '',
+        expected_harvest_date: newFlower.expectedHarvestDate || ''
       })
 
       if (updatedPlant) {

--- a/components/ui/plant-form.tsx
+++ b/components/ui/plant-form.tsx
@@ -9,6 +9,7 @@ import { Textarea } from "@/components/ui/textarea"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible"
 import { ChevronDown, ChevronUp, AlertCircle, Settings, Flower, Info } from "lucide-react"
+import { DUTCH_FLOWERS } from "@/lib/dutch-flowers"
 
 // Standard flower types with emojis
 const STANDARD_FLOWERS = [
@@ -39,6 +40,7 @@ export interface PlantFormData {
   sunPreference: 'full-sun' | 'partial-sun' | 'shade'
   plantingDate: string
   expectedHarvestDate: string
+  bloom_period?: string
   status: "gezond" | "aandacht_nodig" | "ziek" | "dood" | "geoogst"
   notes: string
   careInstructions: string
@@ -89,12 +91,19 @@ export function PlantForm({
       f.name.toLowerCase() === value.toLowerCase()
     )
     
+    // Also check Dutch flowers database for bloom period
+    const dutchFlower = DUTCH_FLOWERS.find(f => 
+      f.name.toLowerCase() === value.toLowerCase() ||
+      f.scientificName?.toLowerCase() === value.toLowerCase()
+    )
+    
     if (selectedFlower) {
       onChange({
         ...data,
         name: value,
         emoji: selectedFlower.emoji,
         color: data.color || selectedFlower.color,
+        bloom_period: dutchFlower?.bloeiperiode || data.bloom_period || '',
         isStandardFlower: true,
       })
     } else {
@@ -102,6 +111,7 @@ export function PlantForm({
         ...data,
         name: value,
         emoji: data.emoji === DEFAULT_FLOWER_EMOJI ? DEFAULT_FLOWER_EMOJI : data.emoji,
+        bloom_period: dutchFlower?.bloeiperiode || data.bloom_period || '',
         isStandardFlower: false,
       })
     }
@@ -558,6 +568,7 @@ export function createInitialPlantFormData(): PlantFormData {
     sunPreference: 'partial-sun',
     plantingDate: "",
     expectedHarvestDate: "",
+    bloom_period: "",
     status: "gezond",
     notes: "",
     careInstructions: "",

--- a/scripts/test-filter.ts
+++ b/scripts/test-filter.ts
@@ -1,0 +1,100 @@
+#!/usr/bin/env ts-node
+
+/**
+ * Test script to verify the month filter logic
+ */
+
+// Test data
+const testPlants = [
+  { name: 'Zinnia', bloom_period: 'Juni-Oktober' },
+  { name: 'Marigold', bloom_period: 'Mei-Oktober' },
+  { name: 'Petunia', bloom_period: 'Mei-Oktober' },
+  { name: 'Cosmos', bloom_period: 'Juli-Oktober' },
+  { name: 'Dahlia', bloom_period: 'Juli-Oktober' },
+  { name: 'Tulp', bloom_period: 'Maart-Mei' },
+  { name: 'Unknown', bloom_period: '' },
+  { name: 'NoBloom', bloom_period: undefined },
+]
+
+// Parse month range helper
+function parseMonthRange(period?: string): number[] {
+  if (!period) return []
+  
+  const monthNames: { [key: string]: number } = {
+    'januari': 1, 'februari': 2, 'maart': 3, 'april': 4,
+    'mei': 5, 'juni': 6, 'juli': 7, 'augustus': 8,
+    'september': 9, 'oktober': 10, 'november': 11, 'december': 12,
+    'jan': 1, 'feb': 2, 'mrt': 3, 'apr': 4, 'jun': 6,
+    'jul': 7, 'aug': 8, 'sep': 9, 'okt': 10, 'nov': 11, 'dec': 12
+  }
+  
+  const parts = period.toLowerCase().split('-')
+  if (parts.length !== 2) return []
+  
+  const startMonth = monthNames[parts[0].trim()]
+  const endMonth = monthNames[parts[1].trim()]
+  
+  if (!startMonth || !endMonth) return []
+  
+  const months: number[] = []
+  let current = startMonth
+  while (current !== endMonth) {
+    months.push(current)
+    current = current === 12 ? 1 : current + 1
+    if (months.length > 12) break
+  }
+  months.push(endMonth)
+  return months
+}
+
+// Get sowing months (2-3 months before blooming)
+function getSowingMonths(bloomPeriod?: string): number[] {
+  const bloomMonths = parseMonthRange(bloomPeriod)
+  if (bloomMonths.length === 0) return []
+  
+  const firstBloomMonth = bloomMonths[0]
+  const sowingMonths: number[] = []
+  
+  for (let i = 2; i <= 3; i++) {
+    let sowMonth = firstBloomMonth - i
+    if (sowMonth <= 0) sowMonth += 12
+    sowingMonths.push(sowMonth)
+  }
+  
+  return sowingMonths
+}
+
+const monthNames = ['Jan', 'Feb', 'Mrt', 'Apr', 'Mei', 'Jun', 
+                   'Jul', 'Aug', 'Sep', 'Okt', 'Nov', 'Dec']
+
+console.log('🌸 Testing Month Filter Logic\n')
+console.log('Test Plants:')
+testPlants.forEach(plant => {
+  console.log(`- ${plant.name}: ${plant.bloom_period || '(no bloom data)'}`)
+})
+
+console.log('\n📅 Testing Bloom Filter:')
+for (let month = 1; month <= 12; month++) {
+  const bloomingPlants = testPlants.filter(plant => {
+    const bloomMonths = parseMonthRange(plant.bloom_period)
+    return bloomMonths.includes(month)
+  })
+  
+  if (bloomingPlants.length > 0) {
+    console.log(`${monthNames[month - 1]}: ${bloomingPlants.map(p => p.name).join(', ')}`)
+  }
+}
+
+console.log('\n🌱 Testing Sowing Filter:')
+for (let month = 1; month <= 12; month++) {
+  const sowingPlants = testPlants.filter(plant => {
+    const sowMonths = getSowingMonths(plant.bloom_period)
+    return sowMonths.includes(month)
+  })
+  
+  if (sowingPlants.length > 0) {
+    console.log(`${monthNames[month - 1]}: ${sowingPlants.map(p => p.name).join(', ')}`)
+  }
+}
+
+console.log('\n✅ Filter test complete!')

--- a/scripts/update-bloom-periods.ts
+++ b/scripts/update-bloom-periods.ts
@@ -1,0 +1,89 @@
+#!/usr/bin/env ts-node
+
+/**
+ * Script to update existing plants with proper bloom_period data
+ * from the Dutch flowers database
+ */
+
+import { supabase } from '../lib/supabase'
+import { DUTCH_FLOWERS } from '../lib/dutch-flowers'
+
+async function updateBloomPeriods() {
+  console.log('🌸 Starting bloom period update...')
+  
+  try {
+    // Fetch all plants
+    const { data: plants, error: fetchError } = await supabase
+      .from('plants')
+      .select('id, name, bloom_period')
+    
+    if (fetchError) {
+      console.error('Error fetching plants:', fetchError)
+      return
+    }
+    
+    if (!plants || plants.length === 0) {
+      console.log('No plants found in database')
+      return
+    }
+    
+    console.log(`Found ${plants.length} plants to check`)
+    
+    let updatedCount = 0
+    let skippedCount = 0
+    
+    for (const plant of plants) {
+      // Skip if plant already has a bloom_period
+      if (plant.bloom_period && plant.bloom_period.trim() !== '') {
+        skippedCount++
+        continue
+      }
+      
+      // Try to find matching Dutch flower data
+      const dutchFlower = DUTCH_FLOWERS.find(f => 
+        f.name.toLowerCase() === plant.name.toLowerCase() ||
+        f.scientificName?.toLowerCase() === plant.name.toLowerCase() ||
+        // Also check for partial matches
+        plant.name.toLowerCase().includes(f.name.toLowerCase()) ||
+        f.name.toLowerCase().includes(plant.name.toLowerCase())
+      )
+      
+      if (dutchFlower) {
+        // Update the plant with bloom period
+        const { error: updateError } = await supabase
+          .from('plants')
+          .update({ bloom_period: dutchFlower.bloeiperiode })
+          .eq('id', plant.id)
+        
+        if (updateError) {
+          console.error(`Error updating plant ${plant.name}:`, updateError)
+        } else {
+          console.log(`✅ Updated ${plant.name} with bloom period: ${dutchFlower.bloeiperiode}`)
+          updatedCount++
+        }
+      } else {
+        console.log(`⚠️ No match found for: ${plant.name}`)
+      }
+    }
+    
+    console.log('\n📊 Summary:')
+    console.log(`- Total plants: ${plants.length}`)
+    console.log(`- Updated: ${updatedCount}`)
+    console.log(`- Skipped (already had bloom_period): ${skippedCount}`)
+    console.log(`- Not matched: ${plants.length - updatedCount - skippedCount}`)
+    
+  } catch (error) {
+    console.error('Unexpected error:', error)
+  }
+}
+
+// Run the script
+updateBloomPeriods()
+  .then(() => {
+    console.log('✨ Bloom period update complete!')
+    process.exit(0)
+  })
+  .catch((error) => {
+    console.error('Script failed:', error)
+    process.exit(1)
+  })


### PR DESCRIPTION
Fixes the garden overview month filter by ensuring `bloom_period` data is correctly populated from the Dutch flowers database during plant creation/update.

The month filter in the garden overview was not working because the `bloom_period` field was either empty or incorrectly set to `expectedHarvestDate` when plants were created or updated. This PR ensures that `bloom_period` is correctly derived from the `DUTCH_FLOWERS` database when a standard flower is selected or a plant is created/updated, and includes a script to backfill existing plant data.

---
<a href="https://cursor.com/background-agent?bcId=bc-1fc8491b-e2f9-4e7c-bc78-bfcd6552f8fc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1fc8491b-e2f9-4e7c-bc78-bfcd6552f8fc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

