### PR TITLE
Remove main page header text

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -239,9 +239,7 @@ function HomePageContent() {
           </div>
           <h1 className="text-3xl sm:text-4xl font-bold text-foreground">Tuinbeheer Systeem</h1>
         </div>
-        <p className="text-base sm:text-xl text-muted-foreground max-w-2xl mx-auto">
-          🌱 Professioneel tuinbeheer met banking-grade kwaliteit en security
-        </p>
+
       </header>
 
       {/* Search and Actions */}


### PR DESCRIPTION
Remove '🌱 Professioneel tuinbeheer met banking-grade kwaliteit en security' from the homepage as requested.

---
<a href="https://cursor.com/background-agent?bcId=bc-52257c3e-3fe5-4dd2-819b-d3406fc4d3ea">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-52257c3e-3fe5-4dd2-819b-d3406fc4d3ea">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

