### PR TITLE
Align garden blocks to larger ones

### DIFF
--- a/app/gardens/[id]/plant-beds/page.tsx
+++ b/app/gardens/[id]/plant-beds/page.tsx
@@ -217,71 +217,73 @@ export default function PlantBedsPage() {
         }>
           {filteredPlantBeds.map((bed) => (
             <Card key={bed.id} className={`hover:shadow-md transition-shadow ${
-              !isVisualView ? 'mb-2' : ''
+              !isVisualView ? 'mb-2' : 'h-full flex flex-col'
             }`}>
-              <CardContent className={isVisualView ? "p-4" : "p-3"}>
+              <CardContent className={`${isVisualView ? "p-4" : "p-3"} ${isVisualView ? "flex-1 flex flex-col" : ""}`}>
 {isVisualView ? (
                   // Visual view - full content
                   <>
-                    <div className="flex items-start justify-between mb-3">
-                      <div className="flex items-center gap-2">
-                        <span className="text-2xl">🌱</span>
-                        <div>
-                          <h3 className="font-medium text-foreground">
-                            <span className="inline-flex items-center justify-center w-8 h-8 bg-blue-100 dark:bg-blue-900 text-blue-800 font-bold rounded-full mr-2">
-                              {bed.letter_code || bed.name}
-                            </span>
-                            Plantvak {bed.letter_code || bed.name}
-                          </h3>
-                          {bed.location && (
-                            <p className="text-sm text-muted-foreground">{bed.location}</p>
-                          )}
-                        </div>
-                      </div>
-                      <div className={`w-3 h-3 rounded-full border-2 ${bed.plants.length > 0 ? 'border-green-500 shadow-green-200' : 'border-gray-500 dark:border-gray-400 shadow-gray-200'}`}></div>
-                    </div>
-                    
-                    <div className="space-y-2 text-sm text-muted-foreground mb-4">
-                      {bed.size && (
-                        <div className="flex justify-between">
-                          <span>Grootte:</span>
-                          <span>{bed.size}</span>
-                        </div>
-                      )}
-                      <div className="flex justify-between">
-                        <span>Planten:</span>
-                        <span>{bed.plants.length}</span>
-                      </div>
-                      {bed.soil_type && (
-                        <div className="flex justify-between">
-                          <span>Grondtype:</span>
-                          <span className="capitalize">{bed.soil_type}</span>
-                        </div>
-                      )}
-                      {bed.sun_exposure && (
-                        <div className="flex justify-between items-center">
-                          <span>Zon:</span>
-                          <div className="flex items-center gap-1">
-                            {getSunExposureIcon(bed.sun_exposure)}
-                            <span>{getSunExposureText(bed.sun_exposure)}</span>
+                    <div className="flex-1">
+                      <div className="flex items-start justify-between mb-3">
+                        <div className="flex items-center gap-2">
+                          <span className="text-2xl">🌱</span>
+                          <div>
+                            <h3 className="font-medium text-foreground">
+                              <span className="inline-flex items-center justify-center w-8 h-8 bg-blue-100 dark:bg-blue-900 text-blue-800 font-bold rounded-full mr-2">
+                                {bed.letter_code || bed.name}
+                              </span>
+                              Plantvak {bed.letter_code || bed.name}
+                            </h3>
+                            {bed.location && (
+                              <p className="text-sm text-muted-foreground">{bed.location}</p>
+                            )}
                           </div>
                         </div>
-                      )}
-                    </div>
-
-                    {/* Show flower emojis preview */}
-                    {bed.plants.length > 0 && (
-                      <div className="flex items-center gap-1 flex-wrap mb-4">
-                        {bed.plants.slice(0, 6).map((plant, index) => (
-                          <span key={index} className="text-lg" title={plant.name}>
-                            {plant.emoji || '🌸'}
-                          </span>
-                        ))}
-                        {bed.plants.length > 6 && (
-                          <span className="text-xs text-muted-foreground ml-1">+{bed.plants.length - 6}</span>
+                        <div className={`w-3 h-3 rounded-full border-2 ${bed.plants.length > 0 ? 'border-green-500 shadow-green-200' : 'border-gray-500 dark:border-gray-400 shadow-gray-200'}`}></div>
+                      </div>
+                      
+                      <div className="space-y-2 text-sm text-muted-foreground mb-4">
+                        {bed.size && (
+                          <div className="flex justify-between">
+                            <span>Grootte:</span>
+                            <span>{bed.size}</span>
+                          </div>
+                        )}
+                        <div className="flex justify-between">
+                          <span>Planten:</span>
+                          <span>{bed.plants.length}</span>
+                        </div>
+                        {bed.soil_type && (
+                          <div className="flex justify-between">
+                            <span>Grondtype:</span>
+                            <span className="capitalize">{bed.soil_type}</span>
+                          </div>
+                        )}
+                        {bed.sun_exposure && (
+                          <div className="flex justify-between items-center">
+                            <span>Zon:</span>
+                            <div className="flex items-center gap-1">
+                              {getSunExposureIcon(bed.sun_exposure)}
+                              <span>{getSunExposureText(bed.sun_exposure)}</span>
+                            </div>
+                          </div>
                         )}
                       </div>
-                    )}
+
+                      {/* Show flower emojis preview */}
+                      {bed.plants.length > 0 && (
+                        <div className="flex items-center gap-1 flex-wrap mb-4">
+                          {bed.plants.slice(0, 6).map((plant, index) => (
+                            <span key={index} className="text-lg" title={plant.name}>
+                              {plant.emoji || '🌸'}
+                            </span>
+                          ))}
+                          {bed.plants.length > 6 && (
+                            <span className="text-xs text-muted-foreground ml-1">+{bed.plants.length - 6}</span>
+                          )}
+                        </div>
+                      )}
+                    </div>
                   </>
                 ) : (
                   // List view - compact content
@@ -324,7 +326,7 @@ export default function PlantBedsPage() {
                 )}
 
 {isVisualView ? (
-                  <div className="flex gap-2">
+                  <div className="flex gap-2 mt-auto">
                     <Button
                       size="sm"
                       variant="outline"

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -498,9 +498,9 @@ function GardenCard({ garden, onDelete }: GardenCardProps) {
   }
 
   return (
-    <Link href={`/gardens/${garden.id}`} className="block">
+    <Link href={`/gardens/${garden.id}`} className="block h-full">
       <Card 
-        className="group hover:shadow-md transition-colors duration-150 border-2 border-green-200 dark:border-green-800 hover:border-green-300 dark:hover:border-green-700 overflow-hidden relative cursor-pointer"
+        className="group hover:shadow-md transition-colors duration-150 border-2 border-green-200 dark:border-green-800 hover:border-green-300 dark:hover:border-green-700 overflow-hidden relative cursor-pointer h-full flex flex-col"
       >
       <CardHeader className="pb-2 pt-3 px-3">
         <div className="flex items-start justify-between">
@@ -519,35 +519,37 @@ function GardenCard({ garden, onDelete }: GardenCardProps) {
         </div>
       </CardHeader>
       
-      <CardContent className="pt-0 pb-3 px-3">
+      <CardContent className="pt-0 pb-3 px-3 flex-1 flex flex-col">
         {/* Plant Preview */}
-        {allFlowers.length > 0 ? (
-          <div className="flex flex-wrap gap-1.5">
-            {allFlowers.slice(0, 6).map((flower, index) => (
-              <div
-                key={`${flower.id}-${index}`}
-                className="inline-flex items-center gap-1 bg-green-100 dark:bg-green-900/30 rounded-lg px-2 py-1.5 text-xs border border-green-300 dark:border-green-700 hover:bg-green-200 dark:hover:bg-green-800/50 transition-colors duration-150"
-                title={flower.name}
-              >
-                <span className="text-sm">{getPlantEmoji(flower.name, flower.emoji)}</span>
-                <span className="truncate max-w-16 font-medium text-green-800 dark:text-green-200">{flower.name}</span>
-              </div>
-            ))}
-            {plantBeds.reduce((total, bed) => total + (bed.plants?.length || 0), 0) > 6 && (
-              <div className="text-xs text-green-700 dark:text-green-300 px-2 py-1 bg-green-200 dark:bg-green-800/50 rounded-lg border border-green-300 dark:border-green-600 font-medium">
-                +{plantBeds.reduce((total, bed) => total + (bed.plants?.length || 0), 0) - 6} meer
-              </div>
-            )}
-          </div>
-        ) : (
-          <div className="text-xs text-muted-foreground italic py-2 text-center">
-            Geen planten
-          </div>
-        )}
+        <div className="flex-1">
+          {allFlowers.length > 0 ? (
+            <div className="flex flex-wrap gap-1.5">
+              {allFlowers.slice(0, 6).map((flower, index) => (
+                <div
+                  key={`${flower.id}-${index}`}
+                  className="inline-flex items-center gap-1 bg-green-100 dark:bg-green-900/30 rounded-lg px-2 py-1.5 text-xs border border-green-300 dark:border-green-700 hover:bg-green-200 dark:hover:bg-green-800/50 transition-colors duration-150"
+                  title={flower.name}
+                >
+                  <span className="text-sm">{getPlantEmoji(flower.name, flower.emoji)}</span>
+                  <span className="truncate max-w-16 font-medium text-green-800 dark:text-green-200">{flower.name}</span>
+                </div>
+              ))}
+              {plantBeds.reduce((total, bed) => total + (bed.plants?.length || 0), 0) > 6 && (
+                <div className="text-xs text-green-700 dark:text-green-300 px-2 py-1 bg-green-200 dark:bg-green-800/50 rounded-lg border border-green-300 dark:border-green-600 font-medium">
+                  +{plantBeds.reduce((total, bed) => total + (bed.plants?.length || 0), 0) - 6} meer
+                </div>
+              )}
+            </div>
+          ) : (
+            <div className="text-xs text-muted-foreground italic py-2 text-center">
+              Geen planten
+            </div>
+          )}
+        </div>
       </CardContent>
       
       {/* Footer met acties */}
-      <div className="px-3 pb-3 flex items-center justify-between">
+      <div className="px-3 pb-3 flex items-center justify-between mt-auto">
         <Button
           variant="ghost"
           size="sm"


### PR DESCRIPTION
Align garden and plant bed cards to ensure consistent equal heights across grid layouts.

This PR fixes an issue where cards in garden and plant bed listings had inconsistent heights due to varying content, leading to misaligned layouts. By applying flexbox properties, all cards now stretch to an equal height, and action buttons are consistently aligned at the bottom.

---
<a href="https://cursor.com/background-agent?bcId=bc-97874be3-2dda-4f87-94b7-5c9306644ee9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-97874be3-2dda-4f87-94b7-5c9306644ee9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

